### PR TITLE
change menubar tools name to gridfinity

### DIFF
--- a/freecad/gridfinity_workbench/init_gui.py
+++ b/freecad/gridfinity_workbench/init_gui.py
@@ -47,8 +47,8 @@ class GridfinityWorkbench(Workbench):
 
         App.Console.PrintMessage("switching to Gridfinity Workbench\n")
 
-        self.appendToolbar("Tools", self.toolbox)
-        self.appendMenu("Tools", self.toolbox)
+        self.appendToolbar("Gridfinity", self.toolbox)
+        self.appendMenu("Gridfinity", self.toolbox)
 
         Gui.addCommand('CreateBinBlank', CreateBinBlank())
         Gui.addCommand('CreateBinBase', CreateBinBase())


### PR DESCRIPTION
Change the name of the menu/toolbar item. Currently this is set to `Tools` which is confusing because by default FreeCad does already have a `Tools` item. 

## Before
![image](https://github.com/user-attachments/assets/6da8c9f5-9807-4783-a4e1-fba330b8b736)

## After
![image](https://github.com/user-attachments/assets/d92f2da7-1cf5-4aae-b607-b23cbab3c03c)
