### PR TITLE
Speed up base creation

### DIFF
--- a/freecad/gridfinity_workbench/baseplate_feature_construction.py
+++ b/freecad/gridfinity_workbench/baseplate_feature_construction.py
@@ -8,7 +8,6 @@ zeromm = Units.Quantity("0 mm")
 
 
 def MakeBaseplateMagnetHoles(self, obj):
-
     hole_pos = obj.GridSize / 2 - obj.MagnetHoleDistanceFromEdge
 
     C1 = Part.makeCylinder(
@@ -144,7 +143,6 @@ def MakeBaseplateMagnetHoles(self, obj):
 
 
 def MakeBPScrewBottomCham(self, obj):
-
     hole_pos = obj.GridSize / 2 - obj.MagnetHoleDistanceFromEdge
 
     CT1 = Part.makeCircle(
@@ -206,7 +204,6 @@ def MakeBPScrewBottomCham(self, obj):
     for x in range(obj.xGridUnits):
         ytranslate = zeromm
         for y in range(obj.yGridUnits):
-
             hm1 = HM1.copy()
 
             hm1.translate(App.Vector(xtranslate, ytranslate, 0))
@@ -225,7 +222,6 @@ def MakeBPScrewBottomCham(self, obj):
 
 
 def MakeBPConnectionHoles(self, obj):
-
     C1 = Part.makeCylinder(
         obj.ConnectionHoleDiameter / 2,
         obj.BaseThickness,
@@ -236,7 +232,9 @@ def MakeBPConnectionHoles(self, obj):
         obj.ConnectionHoleDiameter / 2,
         obj.BaseThickness,
         App.Vector(
-            0, -obj.GridSize / 2 + obj.yTotalWidth - obj.BaseThickness, -obj.TotalHeight + obj.BaseThickness / 2
+            0,
+            -obj.GridSize / 2 + obj.yTotalWidth - obj.BaseThickness,
+            -obj.TotalHeight + obj.BaseThickness / 2,
         ),
         App.Vector(0, 1, 0),
     )
@@ -251,7 +249,9 @@ def MakeBPConnectionHoles(self, obj):
         obj.ConnectionHoleDiameter / 2,
         obj.BaseThickness,
         App.Vector(
-            -obj.GridSize / 2 + obj.xTotalWidth - obj.BaseThickness, 0, -obj.TotalHeight + obj.BaseThickness / 2
+            -obj.GridSize / 2 + obj.xTotalWidth - obj.BaseThickness,
+            0,
+            -obj.TotalHeight + obj.BaseThickness / 2,
         ),
         App.Vector(1, 0, 0),
     )

--- a/freecad/gridfinity_workbench/baseplate_feature_construction.py
+++ b/freecad/gridfinity_workbench/baseplate_feature_construction.py
@@ -115,22 +115,29 @@ def MakeBaseplateMagnetHoles(self, obj):
     xtranslate = zeromm
     ytranslate = zeromm
 
+    HM1 = Part.Solid.multiFuse(C1, [C2, C3, C4, CA1, CA2, CA3, CA4, CH1, CH2, CH3, CH4])
+
     for x in range(obj.xGridUnits):
         ytranslate = zeromm
+
         for y in range(obj.yGridUnits):
+            hm1 = HM1.copy()
 
-            HM1 = Part.Solid.multiFuse(C1, [C2, C3, C4, CA1, CA2, CA3, CA4, CH1, CH2, CH3, CH4])
+            # Translate for next hole
+            hm1.translate(App.Vector(xtranslate, ytranslate, 0))
 
-            HM1.translate(App.Vector(xtranslate, ytranslate, 0))
             if y > 0:
-                HM2 = Part.Solid.fuse(HM1, HM2)
+                HM2 = Part.Solid.fuse(hm1, HM2)
             else:
-                HM2 = HM1
-            ytranslate += obj.GridSize
+                HM2 = hm1
+
+            ytranslate += obj.GridSize  # Track position
+
         if x > 0:
             HM3 = Part.Solid.fuse(HM3, HM2)
         else:
             HM3 = HM2
+
         xtranslate += obj.GridSize
 
     return HM3

--- a/freecad/gridfinity_workbench/baseplate_feature_construction.py
+++ b/freecad/gridfinity_workbench/baseplate_feature_construction.py
@@ -201,17 +201,19 @@ def MakeBPScrewBottomCham(self, obj):
     xtranslate = zeromm
     ytranslate = zeromm
 
+    HM1 = Part.Solid.multiFuse(CH1, [CH2, CH3, CH4])
+
     for x in range(obj.xGridUnits):
         ytranslate = zeromm
         for y in range(obj.yGridUnits):
 
-            HM1 = Part.Solid.multiFuse(CH1, [CH2, CH3, CH4])
+            hm1 = HM1.copy()
 
-            HM1.translate(App.Vector(xtranslate, ytranslate, 0))
+            hm1.translate(App.Vector(xtranslate, ytranslate, 0))
             if y > 0:
-                HM2 = Part.Solid.fuse(HM1, HM2)
+                HM2 = Part.Solid.fuse(hm1, HM2)
             else:
-                HM2 = HM1
+                HM2 = hm1
             ytranslate += obj.GridSize
         if x > 0:
             HM3 = Part.Solid.fuse(HM3, HM2)
@@ -256,33 +258,33 @@ def MakeBPConnectionHoles(self, obj):
 
     xtranslate = zeromm
     ytranslate = zeromm
+    HX1 = Part.Solid.fuse(C1, C2)
 
     for x in range(obj.xGridUnits):
         ytranslate = zeromm
 
-        HX1 = Part.Solid.fuse(C1, C2)
-
-        HX1.translate(App.Vector(xtranslate, ytranslate, 0))
+        hx1 = HX1.copy()
+        hx1.translate(App.Vector(xtranslate, ytranslate, 0))
         if x > 0:
-            HX2 = Part.Solid.fuse(HX1, HX2)
+            HX2 = Part.Solid.fuse(hx1, HX2)
         else:
-            HX2 = HX1
+            HX2 = hx1
 
         xtranslate += obj.GridSize
 
     xtranslate = zeromm
     ytranslate = zeromm
+    HY1 = Part.Solid.fuse(C3, C4)
 
     for x in range(obj.yGridUnits):
         xtranslate = zeromm
 
-        HY1 = Part.Solid.fuse(C3, C4)
-
-        HY1.translate(App.Vector(xtranslate, ytranslate, 0))
+        hy1 = HY1.copy()
+        hy1.translate(App.Vector(xtranslate, ytranslate, 0))
         if x > 0:
-            HY2 = Part.Solid.fuse(HY1, HY2)
+            HY2 = Part.Solid.fuse(hy1, HY2)
         else:
-            HY2 = HY1
+            HY2 = hy1
 
         ytranslate += obj.GridSize
 

--- a/freecad/gridfinity_workbench/baseplate_feature_construction.py
+++ b/freecad/gridfinity_workbench/baseplate_feature_construction.py
@@ -6,39 +6,111 @@ unitmm = Units.Quantity("1 mm")
 
 zeromm = Units.Quantity("0 mm")
 
+
 def MakeBaseplateMagnetHoles(self, obj):
 
-    hole_pos = obj.GridSize/2-obj.MagnetHoleDistanceFromEdge
+    hole_pos = obj.GridSize / 2 - obj.MagnetHoleDistanceFromEdge
 
+    C1 = Part.makeCylinder(
+        obj.MagnetHoleDiameter / 2,
+        obj.MagnetHoleDepth,
+        App.Vector(-hole_pos, -hole_pos, -obj.BaseProfileHeight),
+        App.Vector(0, 0, -1),
+    )
+    C2 = Part.makeCylinder(
+        obj.MagnetHoleDiameter / 2,
+        obj.MagnetHoleDepth,
+        App.Vector(hole_pos, -hole_pos, -obj.BaseProfileHeight),
+        App.Vector(0, 0, -1),
+    )
+    C3 = Part.makeCylinder(
+        obj.MagnetHoleDiameter / 2,
+        obj.MagnetHoleDepth,
+        App.Vector(-hole_pos, hole_pos, -obj.BaseProfileHeight),
+        App.Vector(0, 0, -1),
+    )
+    C4 = Part.makeCylinder(
+        obj.MagnetHoleDiameter / 2,
+        obj.MagnetHoleDepth,
+        App.Vector(hole_pos, hole_pos, -obj.BaseProfileHeight),
+        App.Vector(0, 0, -1),
+    )
 
-    C1 = Part.makeCylinder(obj.MagnetHoleDiameter/2, obj.MagnetHoleDepth, App.Vector(-hole_pos,-hole_pos,-obj.BaseProfileHeight), App.Vector(0,0,-1))
-    C2 = Part.makeCylinder(obj.MagnetHoleDiameter/2, obj.MagnetHoleDepth, App.Vector(hole_pos,-hole_pos,-obj.BaseProfileHeight), App.Vector(0,0,-1))
-    C3 = Part.makeCylinder(obj.MagnetHoleDiameter/2, obj.MagnetHoleDepth, App.Vector(-hole_pos,hole_pos,-obj.BaseProfileHeight), App.Vector(0,0,-1))
-    C4 = Part.makeCylinder(obj.MagnetHoleDiameter/2, obj.MagnetHoleDepth, App.Vector(hole_pos,hole_pos,-obj.BaseProfileHeight), App.Vector(0,0,-1))
+    CA1 = Part.makeCylinder(
+        obj.MagnetBaseHole / 2,
+        obj.MagnetHoleDepth + obj.BaseThickness,
+        App.Vector(-hole_pos, -hole_pos, -obj.BaseProfileHeight),
+        App.Vector(0, 0, -1),
+    )
+    CA2 = Part.makeCylinder(
+        obj.MagnetBaseHole / 2,
+        obj.MagnetHoleDepth + obj.BaseThickness,
+        App.Vector(hole_pos, -hole_pos, -obj.BaseProfileHeight),
+        App.Vector(0, 0, -1),
+    )
+    CA3 = Part.makeCylinder(
+        obj.MagnetBaseHole / 2,
+        obj.MagnetHoleDepth + obj.BaseThickness,
+        App.Vector(-hole_pos, hole_pos, -obj.BaseProfileHeight),
+        App.Vector(0, 0, -1),
+    )
+    CA4 = Part.makeCylinder(
+        obj.MagnetBaseHole / 2,
+        obj.MagnetHoleDepth + obj.BaseThickness,
+        App.Vector(hole_pos, hole_pos, -obj.BaseProfileHeight),
+        App.Vector(0, 0, -1),
+    )
 
-    CA1 = Part.makeCylinder(obj.MagnetBaseHole/2, obj.MagnetHoleDepth+obj.BaseThickness, App.Vector(-hole_pos,-hole_pos,-obj.BaseProfileHeight), App.Vector(0,0,-1))
-    CA2 = Part.makeCylinder(obj.MagnetBaseHole/2, obj.MagnetHoleDepth+obj.BaseThickness, App.Vector(hole_pos,-hole_pos,-obj.BaseProfileHeight), App.Vector(0,0,-1))
-    CA3 = Part.makeCylinder(obj.MagnetBaseHole/2, obj.MagnetHoleDepth+obj.BaseThickness, App.Vector(-hole_pos,hole_pos,-obj.BaseProfileHeight), App.Vector(0,0,-1))
-    CA4 = Part.makeCylinder(obj.MagnetBaseHole/2, obj.MagnetHoleDepth+obj.BaseThickness, App.Vector(hole_pos,hole_pos,-obj.BaseProfileHeight), App.Vector(0,0,-1))
+    CT1 = Part.makeCircle(
+        obj.MagnetHoleDiameter / 2 + obj.MagnetChamfer,
+        App.Vector(-hole_pos, -hole_pos, -obj.BaseProfileHeight),
+        App.Vector(0, 0, 1),
+    )
+    CT2 = Part.makeCircle(
+        obj.MagnetHoleDiameter / 2 + obj.MagnetChamfer,
+        App.Vector(hole_pos, -hole_pos, -obj.BaseProfileHeight),
+        App.Vector(0, 0, 1),
+    )
+    CT3 = Part.makeCircle(
+        obj.MagnetHoleDiameter / 2 + obj.MagnetChamfer,
+        App.Vector(-hole_pos, hole_pos, -obj.BaseProfileHeight),
+        App.Vector(0, 0, 1),
+    )
+    CT4 = Part.makeCircle(
+        obj.MagnetHoleDiameter / 2 + obj.MagnetChamfer,
+        App.Vector(hole_pos, hole_pos, -obj.BaseProfileHeight),
+        App.Vector(0, 0, 1),
+    )
 
-    CT1 = Part.makeCircle(obj.MagnetHoleDiameter/2+obj.MagnetChamfer, App.Vector(-hole_pos,-hole_pos,-obj.BaseProfileHeight), App.Vector(0,0,1))
-    CT2 = Part.makeCircle(obj.MagnetHoleDiameter/2+obj.MagnetChamfer, App.Vector(hole_pos,-hole_pos,-obj.BaseProfileHeight), App.Vector(0,0,1))
-    CT3 = Part.makeCircle(obj.MagnetHoleDiameter/2+obj.MagnetChamfer, App.Vector(-hole_pos,hole_pos,-obj.BaseProfileHeight), App.Vector(0,0,1))
-    CT4 = Part.makeCircle(obj.MagnetHoleDiameter/2+obj.MagnetChamfer, App.Vector(hole_pos,hole_pos,-obj.BaseProfileHeight), App.Vector(0,0,1))
+    CB1 = Part.makeCircle(
+        obj.MagnetHoleDiameter / 2,
+        App.Vector(-hole_pos, -hole_pos, -obj.BaseProfileHeight - obj.MagnetChamfer),
+        App.Vector(0, 0, 1),
+    )
+    CB2 = Part.makeCircle(
+        obj.MagnetHoleDiameter / 2,
+        App.Vector(hole_pos, -hole_pos, -obj.BaseProfileHeight - obj.MagnetChamfer),
+        App.Vector(0, 0, 1),
+    )
+    CB3 = Part.makeCircle(
+        obj.MagnetHoleDiameter / 2,
+        App.Vector(-hole_pos, hole_pos, -obj.BaseProfileHeight - obj.MagnetChamfer),
+        App.Vector(0, 0, 1),
+    )
+    CB4 = Part.makeCircle(
+        obj.MagnetHoleDiameter / 2,
+        App.Vector(hole_pos, hole_pos, -obj.BaseProfileHeight - obj.MagnetChamfer),
+        App.Vector(0, 0, 1),
+    )
 
-    CB1 = Part.makeCircle(obj.MagnetHoleDiameter/2, App.Vector(-hole_pos,-hole_pos,-obj.BaseProfileHeight-obj.MagnetChamfer), App.Vector(0,0,1))
-    CB2 = Part.makeCircle(obj.MagnetHoleDiameter/2, App.Vector(hole_pos,-hole_pos,-obj.BaseProfileHeight-obj.MagnetChamfer), App.Vector(0,0,1))
-    CB3 = Part.makeCircle(obj.MagnetHoleDiameter/2, App.Vector(-hole_pos,hole_pos,-obj.BaseProfileHeight-obj.MagnetChamfer), App.Vector(0,0,1))
-    CB4 = Part.makeCircle(obj.MagnetHoleDiameter/2, App.Vector(hole_pos,hole_pos,-obj.BaseProfileHeight-obj.MagnetChamfer), App.Vector(0,0,1))
-
-    CH1 = [CT1,CB1]
-    CH1 = Part.makeLoft(CH1,True)
-    CH2 = [CT2,CB2]
-    CH2 = Part.makeLoft(CH2,True)
-    CH3 = [CT3,CB3]
-    CH3 = Part.makeLoft(CH3,True)
-    CH4 = [CT4,CB4]
-    CH4 = Part.makeLoft(CH4,True)
+    CH1 = [CT1, CB1]
+    CH1 = Part.makeLoft(CH1, True)
+    CH2 = [CT2, CB2]
+    CH2 = Part.makeLoft(CH2, True)
+    CH3 = [CT3, CB3]
+    CH3 = Part.makeLoft(CH3, True)
+    CH4 = [CT4, CB4]
+    CH4 = Part.makeLoft(CH4, True)
 
     xtranslate = zeromm
     ytranslate = zeromm
@@ -47,44 +119,77 @@ def MakeBaseplateMagnetHoles(self, obj):
         ytranslate = zeromm
         for y in range(obj.yGridUnits):
 
-            HM1 = Part.Solid.multiFuse(C1,[C2,C3,C4,CA1,CA2,CA3,CA4,CH1,CH2,CH3,CH4])
+            HM1 = Part.Solid.multiFuse(C1, [C2, C3, C4, CA1, CA2, CA3, CA4, CH1, CH2, CH3, CH4])
 
-            HM1.translate(App.Vector(xtranslate,ytranslate,0))
-            if y>0:
-                HM2 = Part.Solid.fuse(HM1,HM2)
+            HM1.translate(App.Vector(xtranslate, ytranslate, 0))
+            if y > 0:
+                HM2 = Part.Solid.fuse(HM1, HM2)
             else:
                 HM2 = HM1
             ytranslate += obj.GridSize
-        if x>0:
-            HM3 = Part.Solid.fuse(HM3,HM2)
+        if x > 0:
+            HM3 = Part.Solid.fuse(HM3, HM2)
         else:
             HM3 = HM2
         xtranslate += obj.GridSize
 
     return HM3
 
-def MakeBPScrewBottomCham(self,obj):
 
-    hole_pos = obj.GridSize/2-obj.MagnetHoleDistanceFromEdge
+def MakeBPScrewBottomCham(self, obj):
 
-    CT1 = Part.makeCircle(obj.ScrewHoleDiameter/2+obj.MagnetBottomChamfer, App.Vector(-hole_pos,-hole_pos,-obj.TotalHeight), App.Vector(0,0,1))
-    CT2 = Part.makeCircle(obj.ScrewHoleDiameter/2+obj.MagnetBottomChamfer, App.Vector(hole_pos,-hole_pos,-obj.TotalHeight), App.Vector(0,0,1))
-    CT3 = Part.makeCircle(obj.ScrewHoleDiameter/2+obj.MagnetBottomChamfer, App.Vector(-hole_pos,hole_pos,-obj.TotalHeight), App.Vector(0,0,1))
-    CT4 = Part.makeCircle(obj.ScrewHoleDiameter/2+obj.MagnetBottomChamfer, App.Vector(hole_pos,hole_pos,-obj.TotalHeight), App.Vector(0,0,1))
+    hole_pos = obj.GridSize / 2 - obj.MagnetHoleDistanceFromEdge
 
-    CB1 = Part.makeCircle(obj.ScrewHoleDiameter/2, App.Vector(-hole_pos,-hole_pos,-obj.TotalHeight+obj.MagnetBottomChamfer), App.Vector(0,0,1))
-    CB2 = Part.makeCircle(obj.ScrewHoleDiameter/2, App.Vector(hole_pos,-hole_pos,-obj.TotalHeight+obj.MagnetBottomChamfer), App.Vector(0,0,1))
-    CB3 = Part.makeCircle(obj.ScrewHoleDiameter/2, App.Vector(-hole_pos,hole_pos,-obj.TotalHeight+obj.MagnetBottomChamfer), App.Vector(0,0,1))
-    CB4 = Part.makeCircle(obj.ScrewHoleDiameter/2, App.Vector(hole_pos,hole_pos,-obj.TotalHeight+obj.MagnetBottomChamfer), App.Vector(0,0,1))
+    CT1 = Part.makeCircle(
+        obj.ScrewHoleDiameter / 2 + obj.MagnetBottomChamfer,
+        App.Vector(-hole_pos, -hole_pos, -obj.TotalHeight),
+        App.Vector(0, 0, 1),
+    )
+    CT2 = Part.makeCircle(
+        obj.ScrewHoleDiameter / 2 + obj.MagnetBottomChamfer,
+        App.Vector(hole_pos, -hole_pos, -obj.TotalHeight),
+        App.Vector(0, 0, 1),
+    )
+    CT3 = Part.makeCircle(
+        obj.ScrewHoleDiameter / 2 + obj.MagnetBottomChamfer,
+        App.Vector(-hole_pos, hole_pos, -obj.TotalHeight),
+        App.Vector(0, 0, 1),
+    )
+    CT4 = Part.makeCircle(
+        obj.ScrewHoleDiameter / 2 + obj.MagnetBottomChamfer,
+        App.Vector(hole_pos, hole_pos, -obj.TotalHeight),
+        App.Vector(0, 0, 1),
+    )
 
-    CH1 = [CT1,CB1]
-    CH1 = Part.makeLoft(CH1,True)
-    CH2 = [CT2,CB2]
-    CH2 = Part.makeLoft(CH2,True)
-    CH3 = [CT3,CB3]
-    CH3 = Part.makeLoft(CH3,True)
-    CH4 = [CT4,CB4]
-    CH4 = Part.makeLoft(CH4,True)
+    CB1 = Part.makeCircle(
+        obj.ScrewHoleDiameter / 2,
+        App.Vector(-hole_pos, -hole_pos, -obj.TotalHeight + obj.MagnetBottomChamfer),
+        App.Vector(0, 0, 1),
+    )
+    CB2 = Part.makeCircle(
+        obj.ScrewHoleDiameter / 2,
+        App.Vector(hole_pos, -hole_pos, -obj.TotalHeight + obj.MagnetBottomChamfer),
+        App.Vector(0, 0, 1),
+    )
+    CB3 = Part.makeCircle(
+        obj.ScrewHoleDiameter / 2,
+        App.Vector(-hole_pos, hole_pos, -obj.TotalHeight + obj.MagnetBottomChamfer),
+        App.Vector(0, 0, 1),
+    )
+    CB4 = Part.makeCircle(
+        obj.ScrewHoleDiameter / 2,
+        App.Vector(hole_pos, hole_pos, -obj.TotalHeight + obj.MagnetBottomChamfer),
+        App.Vector(0, 0, 1),
+    )
+
+    CH1 = [CT1, CB1]
+    CH1 = Part.makeLoft(CH1, True)
+    CH2 = [CT2, CB2]
+    CH2 = Part.makeLoft(CH2, True)
+    CH3 = [CT3, CB3]
+    CH3 = Part.makeLoft(CH3, True)
+    CH4 = [CT4, CB4]
+    CH4 = Part.makeLoft(CH4, True)
 
     xtranslate = zeromm
     ytranslate = zeromm
@@ -93,30 +198,54 @@ def MakeBPScrewBottomCham(self,obj):
         ytranslate = zeromm
         for y in range(obj.yGridUnits):
 
-            HM1 = Part.Solid.multiFuse(CH1,[CH2,CH3,CH4])
+            HM1 = Part.Solid.multiFuse(CH1, [CH2, CH3, CH4])
 
-            HM1.translate(App.Vector(xtranslate,ytranslate,0))
-            if y>0:
-                HM2 = Part.Solid.fuse(HM1,HM2)
+            HM1.translate(App.Vector(xtranslate, ytranslate, 0))
+            if y > 0:
+                HM2 = Part.Solid.fuse(HM1, HM2)
             else:
                 HM2 = HM1
             ytranslate += obj.GridSize
-        if x>0:
-            HM3 = Part.Solid.fuse(HM3,HM2)
+        if x > 0:
+            HM3 = Part.Solid.fuse(HM3, HM2)
         else:
             HM3 = HM2
         xtranslate += obj.GridSize
 
     return HM3
 
-def MakeBPConnectionHoles(self,obj):
 
-    C1 = Part.makeCylinder(obj.ConnectionHoleDiameter/2, obj.BaseThickness, App.Vector(0,-obj.GridSize/2,-obj.TotalHeight+obj.BaseThickness/2), App.Vector(0,1,0))
-    C2 = Part.makeCylinder(obj.ConnectionHoleDiameter/2, obj.BaseThickness, App.Vector(0,-obj.GridSize/2+obj.yTotalWidth-obj.BaseThickness,-obj.TotalHeight+obj.BaseThickness/2), App.Vector(0,1,0))
+def MakeBPConnectionHoles(self, obj):
 
+    C1 = Part.makeCylinder(
+        obj.ConnectionHoleDiameter / 2,
+        obj.BaseThickness,
+        App.Vector(0, -obj.GridSize / 2, -obj.TotalHeight + obj.BaseThickness / 2),
+        App.Vector(0, 1, 0),
+    )
+    C2 = Part.makeCylinder(
+        obj.ConnectionHoleDiameter / 2,
+        obj.BaseThickness,
+        App.Vector(
+            0, -obj.GridSize / 2 + obj.yTotalWidth - obj.BaseThickness, -obj.TotalHeight + obj.BaseThickness / 2
+        ),
+        App.Vector(0, 1, 0),
+    )
 
-    C3 = Part.makeCylinder(obj.ConnectionHoleDiameter/2, obj.BaseThickness, App.Vector(-obj.GridSize/2,0,-obj.TotalHeight+obj.BaseThickness/2), App.Vector(1,0,0))
-    C4 = Part.makeCylinder(obj.ConnectionHoleDiameter/2, obj.BaseThickness, App.Vector(-obj.GridSize/2+obj.xTotalWidth-obj.BaseThickness,0,-obj.TotalHeight+obj.BaseThickness/2), App.Vector(1,0,0))
+    C3 = Part.makeCylinder(
+        obj.ConnectionHoleDiameter / 2,
+        obj.BaseThickness,
+        App.Vector(-obj.GridSize / 2, 0, -obj.TotalHeight + obj.BaseThickness / 2),
+        App.Vector(1, 0, 0),
+    )
+    C4 = Part.makeCylinder(
+        obj.ConnectionHoleDiameter / 2,
+        obj.BaseThickness,
+        App.Vector(
+            -obj.GridSize / 2 + obj.xTotalWidth - obj.BaseThickness, 0, -obj.TotalHeight + obj.BaseThickness / 2
+        ),
+        App.Vector(1, 0, 0),
+    )
 
     xtranslate = zeromm
     ytranslate = zeromm
@@ -124,11 +253,11 @@ def MakeBPConnectionHoles(self,obj):
     for x in range(obj.xGridUnits):
         ytranslate = zeromm
 
-        HX1 = Part.Solid.fuse(C1,C2)
+        HX1 = Part.Solid.fuse(C1, C2)
 
-        HX1.translate(App.Vector(xtranslate,ytranslate,0))
-        if x>0:
-            HX2 = Part.Solid.fuse(HX1,HX2)
+        HX1.translate(App.Vector(xtranslate, ytranslate, 0))
+        if x > 0:
+            HX2 = Part.Solid.fuse(HX1, HX2)
         else:
             HX2 = HX1
 
@@ -140,15 +269,15 @@ def MakeBPConnectionHoles(self,obj):
     for x in range(obj.yGridUnits):
         xtranslate = zeromm
 
-        HY1 = Part.Solid.fuse(C3,C4)
+        HY1 = Part.Solid.fuse(C3, C4)
 
-        HY1.translate(App.Vector(xtranslate,ytranslate,0))
-        if x>0:
-            HY2 = Part.Solid.fuse(HY1,HY2)
+        HY1.translate(App.Vector(xtranslate, ytranslate, 0))
+        if x > 0:
+            HY2 = Part.Solid.fuse(HY1, HY2)
         else:
             HY2 = HY1
 
         ytranslate += obj.GridSize
 
-    con_holes = Part.Solid.fuse(HX2,HY2)
+    con_holes = Part.Solid.fuse(HX2, HY2)
     return con_holes

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -6,15 +6,16 @@ import FreeCAD as App
 unitmm = Units.Quantity("1 mm")
 zeromm = Units.Quantity("0 mm")
 
-def createRoundedRectangle(xwidth, ywidth, zsketchplane, radius):
-    xfarv = xwidth/2
-    yfarv = ywidth/2
-    xclosev = xwidth/2-radius
-    yclosev = ywidth/2-radius
-    xarcv = xwidth / 2 - radius + radius * math.sin(math.pi/4)
-    yarcv = ywidth / 2 - radius + radius * math.sin(math.pi/4)
 
-    V1 = App.Vector(-xclosev,yfarv, zsketchplane)
+def createRoundedRectangle(xwidth, ywidth, zsketchplane, radius):
+    xfarv = xwidth / 2
+    yfarv = ywidth / 2
+    xclosev = xwidth / 2 - radius
+    yclosev = ywidth / 2 - radius
+    xarcv = xwidth / 2 - radius + radius * math.sin(math.pi / 4)
+    yarcv = ywidth / 2 - radius + radius * math.sin(math.pi / 4)
+
+    V1 = App.Vector(-xclosev, yfarv, zsketchplane)
     V2 = App.Vector(xclosev, yfarv, zsketchplane)
     V3 = App.Vector(xfarv, yclosev, zsketchplane)
     V4 = App.Vector(xfarv, -yclosev, zsketchplane)
@@ -43,32 +44,47 @@ def createRoundedRectangle(xwidth, ywidth, zsketchplane, radius):
 
     return wire
 
+
 def RoundedRectangleChamfer(xwidth, ywidth, zsketchplane, height, radius):
     w1 = createRoundedRectangle(xwidth, ywidth, zsketchplane, radius)
-    w2 = createRoundedRectangle(xwidth+2*height, ywidth+2*height, zsketchplane+height, radius+height)
-    wires = [w1,w2]
-    return Part.makeLoft(wires,True)
+    w2 = createRoundedRectangle(xwidth + 2 * height, ywidth + 2 * height, zsketchplane + height, radius + height)
+    wires = [w1, w2]
+    return Part.makeLoft(wires, True)
+
+
 def RoundedRectangleExtrude(xwidth, ywidth, zsketchplane, height, radius):
     w1 = createRoundedRectangle(xwidth, ywidth, zsketchplane, radius)
     face = Part.Face(w1)
-    return face.extrude(App.Vector(0,0,height))
+    return face.extrude(App.Vector(0, 0, height))
 
 
 def MakeLabelShelf(self, obj):
 
-    towall = -obj.BinUnit/2 + obj.WallThickness
-    tolabelend = -obj.BinUnit/2 + obj.StackingLipTopChamfer + obj.StackingLipTopLedge + obj.StackingLipBottomChamfer + obj.LabelShelfWidth
-    meetswallbottom = -obj.StackingLipTopChamfer - obj.StackingLipTopLedge - obj.StackingLipBottomChamfer - obj.LabelShelfWidth + obj.WallThickness
+    towall = -obj.BinUnit / 2 + obj.WallThickness
+    tolabelend = (
+        -obj.BinUnit / 2
+        + obj.StackingLipTopChamfer
+        + obj.StackingLipTopLedge
+        + obj.StackingLipBottomChamfer
+        + obj.LabelShelfWidth
+    )
+    meetswallbottom = (
+        -obj.StackingLipTopChamfer
+        - obj.StackingLipTopLedge
+        - obj.StackingLipBottomChamfer
+        - obj.LabelShelfWidth
+        + obj.WallThickness
+    )
 
     fwoverride = False
     xdiv = obj.xDividers + 1
     ydiv = obj.yDividers + 1
-    xcompwidth = (obj.xTotalWidth - obj.WallThickness*2 - obj.DividerThickness*obj.xDividers)/(xdiv)
-    ycompwidth = (obj.yTotalWidth - obj.WallThickness*2 - obj.DividerThickness*obj.yDividers)/(ydiv)
+    xcompwidth = (obj.xTotalWidth - obj.WallThickness * 2 - obj.DividerThickness * obj.xDividers) / (xdiv)
+    ycompwidth = (obj.yTotalWidth - obj.WallThickness * 2 - obj.DividerThickness * obj.yDividers) / (ydiv)
 
     V1 = App.Vector(towall, 0, 0)
     V2 = App.Vector(tolabelend, 0, 0)
-    V3 = App.Vector(tolabelend,0, -obj.LabelShelfVerticalThickness)
+    V3 = App.Vector(tolabelend, 0, -obj.LabelShelfVerticalThickness)
     V4 = App.Vector(towall, 0, meetswallbottom)
 
     L1 = Part.LineSegment(V1, V2)
@@ -76,7 +92,7 @@ def MakeLabelShelf(self, obj):
     L3 = Part.LineSegment(V3, V4)
     L4 = Part.LineSegment(V4, V1)
 
-    S1 = Part.Shape([L1,L2,L3,L4])
+    S1 = Part.Shape([L1, L2, L3, L4])
 
     wire = Part.Wire(S1.Edges)
 
@@ -85,18 +101,17 @@ def MakeLabelShelf(self, obj):
     if obj.LabelShelfLength > ycompwidth:
         fwoverride = True
 
-
     if obj.LabelShelfPlacement == "Full Width" or fwoverride:
 
-        fw = obj.yTotalWidth - obj.WallThickness*2
-        ytranslate = -obj.BinUnit/2 + obj.WallThickness
+        fw = obj.yTotalWidth - obj.WallThickness * 2
+        ytranslate = -obj.BinUnit / 2 + obj.WallThickness
         xtranslate = zeromm
         parts = []
         for x in range(xdiv):
 
-            ls = face.extrude(App.Vector(0,fw,0))
+            ls = face.extrude(App.Vector(0, fw, 0))
 
-            ls.translate(App.Vector(xtranslate,ytranslate,0))
+            ls.translate(App.Vector(xtranslate, ytranslate, 0))
 
             if x == 0:
                 firstls = ls
@@ -105,13 +120,12 @@ def MakeLabelShelf(self, obj):
 
             xtranslate += xcompwidth + obj.DividerThickness
 
-        if xdiv ==1:
+        if xdiv == 1:
             funcfuse = ls
         else:
-            funcfuse = Part.Solid.multiFuse(firstls,parts)
+            funcfuse = Part.Solid.multiFuse(firstls, parts)
 
-
-        x2 = -obj.BinUnit/2 + obj.WallThickness
+        x2 = -obj.BinUnit / 2 + obj.WallThickness
         b_edges = []
         for idx_edge, edge in enumerate(funcfuse.Edges):
             y0 = edge.Vertexes[0].Point.y
@@ -119,12 +133,12 @@ def MakeLabelShelf(self, obj):
             x0 = edge.Vertexes[0].Point.x
             x1 = edge.Vertexes[1].Point.x
 
-            if (y0-y1) == 0 and x1 == x2 and x0 == x2:
+            if (y0 - y1) == 0 and x1 == x2 and x0 == x2:
                 b_edges.append(edge)
 
         funcfuse = funcfuse.makeFillet(obj.BinOuterRadius - obj.WallThickness, b_edges)
 
-        if obj.LabelShelfVerticalThickness > (obj.InsideFilletRadius/2):
+        if obj.LabelShelfVerticalThickness > (obj.InsideFilletRadius / 2):
             h_edges = []
             for idx_edge, edge in enumerate(funcfuse.Edges):
                 z0 = edge.Vertexes[0].Point.z
@@ -135,20 +149,19 @@ def MakeLabelShelf(self, obj):
 
             funcfuse = funcfuse.makeFillet(obj.InsideFilletRadius, h_edges)
 
-
     if obj.LabelShelfPlacement == "Center" and not fwoverride:
 
         xtranslate = zeromm
-        ysp = -obj.BinUnit/2 + obj.WallThickness + ycompwidth/2 - obj.LabelShelfLength/2
+        ysp = -obj.BinUnit / 2 + obj.WallThickness + ycompwidth / 2 - obj.LabelShelfLength / 2
         ytranslate = ysp
         parts = []
         for x in range(xdiv):
             ytranslate = ysp
             for y in range(ydiv):
 
-                ls = face.extrude(App.Vector(0,obj.LabelShelfLength,0))
+                ls = face.extrude(App.Vector(0, obj.LabelShelfLength, 0))
 
-                ls.translate(App.Vector(xtranslate,ytranslate,0))
+                ls.translate(App.Vector(xtranslate, ytranslate, 0))
 
                 if x == 0 and y == 0:
                     firstls = ls
@@ -162,9 +175,9 @@ def MakeLabelShelf(self, obj):
         if xdiv == 1 and ydiv == 1:
             funcfuse = ls
         else:
-            funcfuse = Part.Solid.multiFuse(firstls,parts)
+            funcfuse = Part.Solid.multiFuse(firstls, parts)
 
-        if obj.LabelShelfVerticalThickness > (obj.InsideFilletRadius/2):
+        if obj.LabelShelfVerticalThickness > (obj.InsideFilletRadius / 2):
             h_edges = []
             for idx_edge, edge in enumerate(funcfuse.Edges):
                 z0 = edge.Vertexes[0].Point.z
@@ -175,19 +188,18 @@ def MakeLabelShelf(self, obj):
 
             funcfuse = funcfuse.makeFillet(obj.InsideFilletRadius, h_edges)
 
-
     if obj.LabelShelfPlacement == "Left" and not fwoverride:
         xtranslate = zeromm
-        ysp = -obj.BinUnit/2 + obj.WallThickness
+        ysp = -obj.BinUnit / 2 + obj.WallThickness
         ytranslate = ysp
         parts = []
         for x in range(xdiv):
             ytranslate = ysp
             for y in range(ydiv):
 
-                ls = face.extrude(App.Vector(0,obj.LabelShelfLength,0))
+                ls = face.extrude(App.Vector(0, obj.LabelShelfLength, 0))
 
-                ls.translate(App.Vector(xtranslate,ytranslate,0))
+                ls.translate(App.Vector(xtranslate, ytranslate, 0))
 
                 if x == 0 and y == 0:
                     firstls = ls
@@ -198,13 +210,12 @@ def MakeLabelShelf(self, obj):
 
             xtranslate += xcompwidth + obj.DividerThickness
 
-        if xdiv ==1 and ydiv == 1:
+        if xdiv == 1 and ydiv == 1:
             funcfuse = ls
         else:
-            funcfuse = Part.Solid.multiFuse(firstls,parts)
+            funcfuse = Part.Solid.multiFuse(firstls, parts)
 
-
-        y2 = -obj.BinUnit/2 + obj.WallThickness
+        y2 = -obj.BinUnit / 2 + obj.WallThickness
         b_edges = []
         for idx_edge, edge in enumerate(funcfuse.Edges):
             y0 = edge.Vertexes[0].Point.y
@@ -217,7 +228,7 @@ def MakeLabelShelf(self, obj):
 
         funcfuse = funcfuse.makeFillet(obj.BinOuterRadius - obj.WallThickness, b_edges)
 
-        if obj.LabelShelfVerticalThickness > (obj.InsideFilletRadius/2):
+        if obj.LabelShelfVerticalThickness > (obj.InsideFilletRadius / 2):
             h_edges = []
             for idx_edge, edge in enumerate(funcfuse.Edges):
                 z0 = edge.Vertexes[0].Point.z
@@ -228,19 +239,18 @@ def MakeLabelShelf(self, obj):
 
             funcfuse = funcfuse.makeFillet(obj.InsideFilletRadius, h_edges)
 
-
     if obj.LabelShelfPlacement == "Right" and not fwoverride:
         xtranslate = zeromm
-        ysp = -obj.BinUnit/2 + obj.WallThickness + ycompwidth - obj.LabelShelfLength
+        ysp = -obj.BinUnit / 2 + obj.WallThickness + ycompwidth - obj.LabelShelfLength
         ytranslate = ysp
         parts = []
         for x in range(xdiv):
             ytranslate = ysp
             for y in range(ydiv):
 
-                ls = face.extrude(App.Vector(0,obj.LabelShelfLength,0))
+                ls = face.extrude(App.Vector(0, obj.LabelShelfLength, 0))
 
-                ls.translate(App.Vector(xtranslate,ytranslate,0))
+                ls.translate(App.Vector(xtranslate, ytranslate, 0))
 
                 if x == 0 and y == 0:
                     firstls = ls
@@ -251,14 +261,13 @@ def MakeLabelShelf(self, obj):
 
             xtranslate += xcompwidth + obj.DividerThickness
 
-        if xdiv ==1 and ydiv == 1:
+        if xdiv == 1 and ydiv == 1:
             funcfuse = ls
         else:
-            funcfuse = Part.Solid.multiFuse(firstls,parts)
+            funcfuse = Part.Solid.multiFuse(firstls, parts)
 
-
-        y2 = obj.yTotalWidth - obj.BinUnit/2 - obj.WallThickness
-        x2 = -obj.BinUnit/2 + obj.WallThickness
+        y2 = obj.yTotalWidth - obj.BinUnit / 2 - obj.WallThickness
+        x2 = -obj.BinUnit / 2 + obj.WallThickness
         b_edges = []
         for idx_edge, edge in enumerate(funcfuse.Edges):
             y0 = edge.Vertexes[0].Point.y
@@ -271,7 +280,7 @@ def MakeLabelShelf(self, obj):
 
         funcfuse = funcfuse.makeFillet(obj.BinOuterRadius - obj.WallThickness, b_edges)
 
-        if obj.LabelShelfVerticalThickness > (obj.InsideFilletRadius/2):
+        if obj.LabelShelfVerticalThickness > (obj.InsideFilletRadius / 2):
             h_edges = []
             for idx_edge, edge in enumerate(funcfuse.Edges):
                 z0 = edge.Vertexes[0].Point.z
@@ -282,65 +291,86 @@ def MakeLabelShelf(self, obj):
 
             funcfuse = funcfuse.makeFillet(obj.InsideFilletRadius, h_edges)
 
-
     return funcfuse
 
-def MakeScoop(self, obj):
-    scooprad1 = obj.ScoopRadius+1*unitmm
-    scooprad2 = obj.ScoopRadius+1*unitmm
-    scooprad3 = obj.ScoopRadius+1*unitmm
 
-    xcomp_w = (obj.xTotalWidth-obj.WallThickness*2-obj.xDividers*obj.DividerThickness)/(obj.xDividers+1)
+def MakeScoop(self, obj):
+    scooprad1 = obj.ScoopRadius + 1 * unitmm
+    scooprad2 = obj.ScoopRadius + 1 * unitmm
+    scooprad3 = obj.ScoopRadius + 1 * unitmm
+
+    xcomp_w = (obj.xTotalWidth - obj.WallThickness * 2 - obj.xDividers * obj.DividerThickness) / (obj.xDividers + 1)
 
     xdivscoop = obj.xDividerHeight - obj.HeightUnitValue
 
     if obj.ScoopRadius > xdivscoop and obj.xDividerHeight != 0:
-        scooprad1 = xdivscoop-unitmm
+        scooprad1 = xdivscoop - unitmm
     if obj.ScoopRadius > xcomp_w and obj.xDividers > 0:
-        scooprad2 = xcomp_w-2*unitmm
+        scooprad2 = xcomp_w - 2 * unitmm
     if obj.ScoopRadius > obj.UsableHeight > 0:
         scooprad3 = obj.UsableHeight
 
-    scooprad = min(obj.ScoopRadius,scooprad1,scooprad2,scooprad3)
+    scooprad = min(obj.ScoopRadius, scooprad1, scooprad2, scooprad3)
 
     if scooprad <= 0:
         App.Console.PrintMessage("scooop could not be made due to bin selected parameters\n")
         return
 
-    V1 = App.Vector(obj.xTotalWidth-obj.BinUnit/2-obj.WallThickness, 0, -obj.UsableHeight + scooprad)
-    V2 = App.Vector(obj.xTotalWidth-obj.BinUnit/2-obj.WallThickness, 0, -obj.UsableHeight)
-    V3 = App.Vector(obj.xTotalWidth-obj.BinUnit/2-obj.WallThickness - scooprad, 0, -obj.UsableHeight)
+    V1 = App.Vector(obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness, 0, -obj.UsableHeight + scooprad)
+    V2 = App.Vector(obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness, 0, -obj.UsableHeight)
+    V3 = App.Vector(obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness - scooprad, 0, -obj.UsableHeight)
 
     L1 = Part.LineSegment(V1, V2)
     L2 = Part.LineSegment(V2, V3)
 
-    VC1 = App.Vector(obj.xTotalWidth-obj.BinUnit/2-obj.WallThickness - scooprad + scooprad * math.sin(math.pi/4),0,-obj.UsableHeight + scooprad - scooprad * math.sin(math.pi/4))
+    VC1 = App.Vector(
+        obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness - scooprad + scooprad * math.sin(math.pi / 4),
+        0,
+        -obj.UsableHeight + scooprad - scooprad * math.sin(math.pi / 4),
+    )
 
     C1 = Part.Arc(V1, VC1, V3)
 
-    S1 = Part.Shape([L1,L2,C1])
+    S1 = Part.Shape([L1, L2, C1])
 
     wire = Part.Wire(S1.Edges)
 
     face = Part.Face(wire)
 
     xdiv = obj.xDividers + 1
-    xtranslate = 0 * unitmm -obj.WallThickness + obj.StackingLipTopLedge + obj.StackingLipTopChamfer + obj.StackingLipBottomChamfer
-    compwidth = (obj.xTotalWidth - obj.WallThickness*2 - obj.DividerThickness*obj.xDividers)/(xdiv)
+    xtranslate = (
+        0 * unitmm
+        - obj.WallThickness
+        + obj.StackingLipTopLedge
+        + obj.StackingLipTopChamfer
+        + obj.StackingLipBottomChamfer
+    )
+    compwidth = (obj.xTotalWidth - obj.WallThickness * 2 - obj.DividerThickness * obj.xDividers) / (xdiv)
 
-    scoopbox = Part.makeBox(obj.StackingLipBottomChamfer + obj.StackingLipTopChamfer + obj.StackingLipTopLedge - obj.WallThickness ,obj.yTotalWidth-obj.WallThickness*2,obj.UsableHeight,App.Vector(obj.xTotalWidth - obj.BinUnit/2 - obj.WallThickness,-obj.BinUnit/2 + obj.WallThickness,0),App.Vector(0,0,-1))
+    scoopbox = Part.makeBox(
+        obj.StackingLipBottomChamfer + obj.StackingLipTopChamfer + obj.StackingLipTopLedge - obj.WallThickness,
+        obj.yTotalWidth - obj.WallThickness * 2,
+        obj.UsableHeight,
+        App.Vector(obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness, -obj.BinUnit / 2 + obj.WallThickness, 0),
+        App.Vector(0, 0, -1),
+    )
 
     parts = []
     for x in range(xdiv):
-        scoop = face.extrude(App.Vector(0,obj.yTotalWidth - obj.WallThickness*2,0))
-        scoop.translate(App.Vector(-xtranslate,-obj.BinUnit/2 + obj.WallThickness,0))
+        scoop = face.extrude(App.Vector(0, obj.yTotalWidth - obj.WallThickness * 2, 0))
+        scoop.translate(App.Vector(-xtranslate, -obj.BinUnit / 2 + obj.WallThickness, 0))
 
         if x > 0:
             xtranslate += compwidth + obj.DividerThickness
         else:
-            xtranslate += + obj.WallThickness - obj.StackingLipTopLedge - obj.StackingLipTopChamfer - obj.StackingLipBottomChamfer + compwidth + obj.DividerThickness
-
-
+            xtranslate += (
+                +obj.WallThickness
+                - obj.StackingLipTopLedge
+                - obj.StackingLipTopChamfer
+                - obj.StackingLipBottomChamfer
+                + compwidth
+                + obj.DividerThickness
+            )
 
         if x > 0:
             parts.append(scoop)
@@ -357,27 +387,60 @@ def MakeScoop(self, obj):
         x0 = edge.Vertexes[0].Point.x
         x1 = edge.Vertexes[1].Point.x
 
-        hdif = abs(z0-z1)
+        hdif = abs(z0 - z1)
         if hdif == obj.UsableHeight and x0 == x1:
             b_edges.append(edge)
 
-    funcfuse = funcfuse.makeFillet(obj.StackingLipBottomChamfer + obj.StackingLipTopChamfer + obj.StackingLipTopLedge - obj.WallThickness - 0.01*unitmm, b_edges)
+    funcfuse = funcfuse.makeFillet(
+        obj.StackingLipBottomChamfer
+        + obj.StackingLipTopChamfer
+        + obj.StackingLipTopLedge
+        - obj.WallThickness
+        - 0.01 * unitmm,
+        b_edges,
+    )
 
     return funcfuse
+
 
 def MakeStackingLip(self, obj):
 
     stacking_lip_path = createRoundedRectangle(obj.xTotalWidth, obj.yTotalWidth, 0, obj.BinOuterRadius)
-    stacking_lip_path.translate(App.Vector(obj.xTotalWidth/2-obj.BinUnit/2,obj.yTotalWidth/2-obj.BinUnit/2,0))
-    ST1 = App.Vector(-obj.BinUnit/2,0,0)
-    ST2 = App.Vector(-obj.BinUnit/2,0,obj.StackingLipBottomChamfer+obj.StackingLipVerticalSection+obj.StackingLipTopChamfer)
-    ST3 = App.Vector(-obj.BinUnit/2+obj.StackingLipTopLedge,0,obj.StackingLipBottomChamfer+obj.StackingLipVerticalSection+obj.StackingLipTopChamfer)
-    ST4 = App.Vector(-obj.BinUnit/2+obj.StackingLipTopLedge+obj.StackingLipTopChamfer,0,obj.StackingLipBottomChamfer+obj.StackingLipVerticalSection)
-    ST5 = App.Vector(-obj.BinUnit/2+obj.StackingLipTopLedge+obj.StackingLipTopChamfer,0,obj.StackingLipBottomChamfer)
-    ST6 = App.Vector(-obj.BinUnit/2+obj.StackingLipTopLedge+obj.StackingLipTopChamfer+obj.StackingLipBottomChamfer,0,0)
-    ST7 = App.Vector(-obj.BinUnit/2+obj.StackingLipTopLedge+obj.StackingLipTopChamfer+obj.StackingLipBottomChamfer,0,-obj.StackingLipVerticalSection)
-    ST8 = App.Vector(-obj.BinUnit/2+obj.WallThickness,0,-obj.StackingLipVerticalSection-(obj.StackingLipTopLedge+obj.StackingLipTopChamfer+obj.StackingLipBottomChamfer-obj.WallThickness))
-    ST9 = App.Vector(-obj.BinUnit/2+obj.WallThickness,0,0)
+    stacking_lip_path.translate(
+        App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0)
+    )
+    ST1 = App.Vector(-obj.BinUnit / 2, 0, 0)
+    ST2 = App.Vector(
+        -obj.BinUnit / 2, 0, obj.StackingLipBottomChamfer + obj.StackingLipVerticalSection + obj.StackingLipTopChamfer
+    )
+    ST3 = App.Vector(
+        -obj.BinUnit / 2 + obj.StackingLipTopLedge,
+        0,
+        obj.StackingLipBottomChamfer + obj.StackingLipVerticalSection + obj.StackingLipTopChamfer,
+    )
+    ST4 = App.Vector(
+        -obj.BinUnit / 2 + obj.StackingLipTopLedge + obj.StackingLipTopChamfer,
+        0,
+        obj.StackingLipBottomChamfer + obj.StackingLipVerticalSection,
+    )
+    ST5 = App.Vector(
+        -obj.BinUnit / 2 + obj.StackingLipTopLedge + obj.StackingLipTopChamfer, 0, obj.StackingLipBottomChamfer
+    )
+    ST6 = App.Vector(
+        -obj.BinUnit / 2 + obj.StackingLipTopLedge + obj.StackingLipTopChamfer + obj.StackingLipBottomChamfer, 0, 0
+    )
+    ST7 = App.Vector(
+        -obj.BinUnit / 2 + obj.StackingLipTopLedge + obj.StackingLipTopChamfer + obj.StackingLipBottomChamfer,
+        0,
+        -obj.StackingLipVerticalSection,
+    )
+    ST8 = App.Vector(
+        -obj.BinUnit / 2 + obj.WallThickness,
+        0,
+        -obj.StackingLipVerticalSection
+        - (obj.StackingLipTopLedge + obj.StackingLipTopChamfer + obj.StackingLipBottomChamfer - obj.WallThickness),
+    )
+    ST9 = App.Vector(-obj.BinUnit / 2 + obj.WallThickness, 0, 0)
 
     STL1 = Part.LineSegment(ST1, ST2)
     STL2 = Part.LineSegment(ST2, ST3)
@@ -398,55 +461,73 @@ def MakeStackingLip(self, obj):
     stacking_lip = Part.makeSolid(stacking_lip)
     return stacking_lip
 
+
 def MakeCompartements(self, obj):
 
-    xdivheight = obj.xDividerHeight if obj.xDividerHeight !=0 else obj.TotalHeight
-    ydivheight = obj.yDividerHeight if obj.yDividerHeight !=0 else obj.TotalHeight
+    xdivheight = obj.xDividerHeight if obj.xDividerHeight != 0 else obj.TotalHeight
+    ydivheight = obj.yDividerHeight if obj.yDividerHeight != 0 else obj.TotalHeight
 
-    func_fuse= RoundedRectangleExtrude(obj.xTotalWidth-obj.WallThickness*2, obj.yTotalWidth-obj.WallThickness*2, -obj.UsableHeight, obj.UsableHeight, obj.BinOuterRadius-obj.WallThickness)
-    func_fuse.translate(App.Vector(obj.xTotalWidth/2-obj.BinUnit/2,obj.yTotalWidth/2-obj.BinUnit/2,0))
+    func_fuse = RoundedRectangleExtrude(
+        obj.xTotalWidth - obj.WallThickness * 2,
+        obj.yTotalWidth - obj.WallThickness * 2,
+        -obj.UsableHeight,
+        obj.UsableHeight,
+        obj.BinOuterRadius - obj.WallThickness,
+    )
+    func_fuse.translate(App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0))
 
     if obj.xDividers == 0 and obj.yDividers == 0:
-            #Fillet Bottom edges
-            b_edges = []
-            for idx_edge, edge in enumerate(func_fuse.Edges):
-                z0 = edge.Vertexes[0].Point.z
-                z1 = edge.Vertexes[1].Point.z
+        # Fillet Bottom edges
+        b_edges = []
+        for idx_edge, edge in enumerate(func_fuse.Edges):
+            z0 = edge.Vertexes[0].Point.z
+            z1 = edge.Vertexes[1].Point.z
 
-                if z0 < 0 and z1 < 0:
-                    b_edges.append(edge)
+            if z0 < 0 and z1 < 0:
+                b_edges.append(edge)
 
-            func_fuse = func_fuse.makeFillet(obj.InsideFilletRadius, b_edges)
+        func_fuse = func_fuse.makeFillet(obj.InsideFilletRadius, b_edges)
 
     else:
-        xcomp_w = (obj.xTotalWidth-obj.WallThickness*2-obj.xDividers*obj.DividerThickness)/(obj.xDividers+1)
-        ycomp_w = (obj.yTotalWidth-obj.WallThickness*2-obj.yDividers*obj.DividerThickness)/(obj.yDividers+1)
-
+        xcomp_w = (obj.xTotalWidth - obj.WallThickness * 2 - obj.xDividers * obj.DividerThickness) / (obj.xDividers + 1)
+        ycomp_w = (obj.yTotalWidth - obj.WallThickness * 2 - obj.yDividers * obj.DividerThickness) / (obj.yDividers + 1)
 
         xtranslate = zeromm + xcomp_w + obj.WallThickness - obj.DividerThickness
         ytranslate = zeromm + ycomp_w + obj.WallThickness
 
         # dividers in x direction
         for x in range(obj.xDividers):
-            comp = Part.makeBox(obj.DividerThickness,obj.yTotalWidth,xdivheight,App.Vector(-obj.BinUnit/2+obj.DividerThickness,-obj.BinUnit/2,-obj.TotalHeight),App.Vector(0,0,1))
-            comp.translate(App.Vector(xtranslate,0,0))
-            if x>0:
+            comp = Part.makeBox(
+                obj.DividerThickness,
+                obj.yTotalWidth,
+                xdivheight,
+                App.Vector(-obj.BinUnit / 2 + obj.DividerThickness, -obj.BinUnit / 2, -obj.TotalHeight),
+                App.Vector(0, 0, 1),
+            )
+            comp.translate(App.Vector(xtranslate, 0, 0))
+            if x > 0:
                 xdiv = xdiv.fuse(comp)
 
             else:
                 xdiv = comp
-            xtranslate += xcomp_w +obj.DividerThickness
+            xtranslate += xcomp_w + obj.DividerThickness
 
         # dividers in y direction
         for y in range(obj.yDividers):
-            comp = Part.makeBox(obj.xTotalWidth,obj.DividerThickness,ydivheight,App.Vector(-obj.BinUnit/2,-obj.BinUnit/2,-obj.TotalHeight),App.Vector(0,0,1))
+            comp = Part.makeBox(
+                obj.xTotalWidth,
+                obj.DividerThickness,
+                ydivheight,
+                App.Vector(-obj.BinUnit / 2, -obj.BinUnit / 2, -obj.TotalHeight),
+                App.Vector(0, 0, 1),
+            )
 
-            comp.translate(App.Vector(0,ytranslate,0))
-            if y>0:
+            comp.translate(App.Vector(0, ytranslate, 0))
+            if y > 0:
                 ydiv = ydiv.fuse(comp)
             else:
                 ydiv = comp
-            ytranslate += ycomp_w +obj.DividerThickness
+            ytranslate += ycomp_w + obj.DividerThickness
 
         if obj.xDividers > 0:
             func_fuse = func_fuse.cut(xdiv)
@@ -467,18 +548,32 @@ def MakeCompartements(self, obj):
 
     return func_fuse
 
+
 def MakeBinWall(self, obj):
 
     bin_wall_path = createRoundedRectangle(obj.xTotalWidth, obj.yTotalWidth, 0, obj.BinOuterRadius)
-    bin_wall_path.translate(App.Vector(obj.xTotalWidth/2-obj.BinUnit/2,obj.yTotalWidth/2-obj.BinUnit/2,0))
-    ST1 = App.Vector(-obj.BinUnit/2,0,-obj.TotalHeight+obj.BaseProfileHeight)
-    ST2 = App.Vector(-obj.BinUnit/2,0,0)
-    ST3 = App.Vector(-obj.BinUnit/2+obj.WallThickness,0,0)
-    ST4 = App.Vector(-obj.BinUnit/2+obj.WallThickness,0,-obj.TotalHeight+obj.HeightUnitValue+obj.InsideFilletRadius)
-    ST5 = App.Vector(-obj.BinUnit/2+obj.WallThickness+obj.InsideFilletRadius,0,-obj.TotalHeight+obj.HeightUnitValue)
-    ST6 = App.Vector(-obj.BinUnit/2+obj.WallThickness+obj.InsideFilletRadius,0,-obj.TotalHeight+obj.BaseProfileHeight)
+    bin_wall_path.translate(App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0))
+    ST1 = App.Vector(-obj.BinUnit / 2, 0, -obj.TotalHeight + obj.BaseProfileHeight)
+    ST2 = App.Vector(-obj.BinUnit / 2, 0, 0)
+    ST3 = App.Vector(-obj.BinUnit / 2 + obj.WallThickness, 0, 0)
+    ST4 = App.Vector(
+        -obj.BinUnit / 2 + obj.WallThickness, 0, -obj.TotalHeight + obj.HeightUnitValue + obj.InsideFilletRadius
+    )
+    ST5 = App.Vector(
+        -obj.BinUnit / 2 + obj.WallThickness + obj.InsideFilletRadius, 0, -obj.TotalHeight + obj.HeightUnitValue
+    )
+    ST6 = App.Vector(
+        -obj.BinUnit / 2 + obj.WallThickness + obj.InsideFilletRadius, 0, -obj.TotalHeight + obj.BaseProfileHeight
+    )
 
-    VC1 = App.Vector(-obj.BinUnit/2+obj.WallThickness+obj.InsideFilletRadius-obj.InsideFilletRadius * math.sin(math.pi/4),0,-obj.TotalHeight+obj.HeightUnitValue+obj.InsideFilletRadius-+obj.InsideFilletRadius * math.sin(math.pi/4))
+    VC1 = App.Vector(
+        -obj.BinUnit / 2 + obj.WallThickness + obj.InsideFilletRadius - obj.InsideFilletRadius * math.sin(math.pi / 4),
+        0,
+        -obj.TotalHeight
+        + obj.HeightUnitValue
+        + obj.InsideFilletRadius
+        - +obj.InsideFilletRadius * math.sin(math.pi / 4),
+    )
 
     STL1 = Part.LineSegment(ST1, ST2)
     STL2 = Part.LineSegment(ST2, ST3)
@@ -497,156 +592,207 @@ def MakeBinWall(self, obj):
     return bin_wall
 
 
-
 def MakeBinBase(self, obj):
-    components=[]
+    components = []
     basecomp = []
-    bt_cmf_width = obj.BinUnit - 2*obj.BaseProfileBottomChamfer-2*obj.BaseProfileTopChamfer
-    vert_width = obj.BinUnit - 2*obj.BaseProfileTopChamfer
+    bt_cmf_width = obj.BinUnit - 2 * obj.BaseProfileBottomChamfer - 2 * obj.BaseProfileTopChamfer
+    vert_width = obj.BinUnit - 2 * obj.BaseProfileTopChamfer
     xtranslate = zeromm
     ytranslate = zeromm
     for x in range(obj.xGridUnits):
         ytranslate = zeromm
         for y in range(obj.yGridUnits):
-            bottom_chamfer = RoundedRectangleChamfer(bt_cmf_width, bt_cmf_width, -obj.TotalHeight,obj.BaseProfileBottomChamfer, obj.BinBottomRadius)
+            bottom_chamfer = RoundedRectangleChamfer(
+                bt_cmf_width, bt_cmf_width, -obj.TotalHeight, obj.BaseProfileBottomChamfer, obj.BinBottomRadius
+            )
 
-            vertical_section = RoundedRectangleExtrude(vert_width, vert_width, -obj.TotalHeight +obj.BaseProfileBottomChamfer, obj.BaseProfileVerticalSection, obj.BinVerticalRadius)
-            assembly = Part.Shape.fuse(bottom_chamfer,vertical_section)
+            vertical_section = RoundedRectangleExtrude(
+                vert_width,
+                vert_width,
+                -obj.TotalHeight + obj.BaseProfileBottomChamfer,
+                obj.BaseProfileVerticalSection,
+                obj.BinVerticalRadius,
+            )
+            assembly = Part.Shape.fuse(bottom_chamfer, vertical_section)
 
-            top_chamfer = RoundedRectangleChamfer(vert_width, vert_width, -obj.TotalHeight+obj.BaseProfileBottomChamfer+obj.BaseProfileVerticalSection, obj.BaseProfileTopChamfer, obj.BinVerticalRadius)
-            assembly = Part.Solid.fuse(assembly,top_chamfer)
+            top_chamfer = RoundedRectangleChamfer(
+                vert_width,
+                vert_width,
+                -obj.TotalHeight + obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection,
+                obj.BaseProfileTopChamfer,
+                obj.BinVerticalRadius,
+            )
+            assembly = Part.Solid.fuse(assembly, top_chamfer)
 
-
-            assembly.translate(App.Vector(xtranslate,ytranslate,0))
-            if y>0:
-                totalassembly1 = Part.Solid.fuse(assembly,totalassembly1)
+            assembly.translate(App.Vector(xtranslate, ytranslate, 0))
+            if y > 0:
+                totalassembly1 = Part.Solid.fuse(assembly, totalassembly1)
             else:
                 totalassembly1 = assembly
             ytranslate += obj.GridSize
-        if x>0:
-            totalassembly2 = Part.Solid.fuse(totalassembly2,totalassembly1)
+        if x > 0:
+            totalassembly2 = Part.Solid.fuse(totalassembly2, totalassembly1)
         else:
             totalassembly2 = totalassembly1
         xtranslate += obj.GridSize
 
     return totalassembly2
+
+
 def MakeBaseplateCenterCut(self, obj):
 
-    inframedis = obj.GridSize/2-obj.BaseProfileTopChamfer-obj.BaseProfileBottomChamfer - obj.BaseplateTopLedgeWidth
-    magedge = obj.GridSize/2 - obj.MagnetHoleDistanceFromEdge - obj.MagnetHoleDiameter/2 - obj.MagnetEdgeThickness
-    magcenter = obj.GridSize/2 - obj.MagnetHoleDistanceFromEdge
-    smfillpos = inframedis - obj.SmallFillet +obj.SmallFillet * math.sin(math.pi/4)
-    smfillposmag = magedge- obj.SmallFillet + obj.SmallFillet * math.sin(math.pi/4)
-    smfilloffcen = obj.GridSize/2 - obj.MagnetHoleDistanceFromEdge - obj.MagnetHoleDiameter/2 -obj.MagnetEdgeThickness - obj.SmallFillet
+    inframedis = (
+        obj.GridSize / 2 - obj.BaseProfileTopChamfer - obj.BaseProfileBottomChamfer - obj.BaseplateTopLedgeWidth
+    )
+    magedge = obj.GridSize / 2 - obj.MagnetHoleDistanceFromEdge - obj.MagnetHoleDiameter / 2 - obj.MagnetEdgeThickness
+    magcenter = obj.GridSize / 2 - obj.MagnetHoleDistanceFromEdge
+    smfillpos = inframedis - obj.SmallFillet + obj.SmallFillet * math.sin(math.pi / 4)
+    smfillposmag = magedge - obj.SmallFillet + obj.SmallFillet * math.sin(math.pi / 4)
+    smfilloffcen = (
+        obj.GridSize / 2
+        - obj.MagnetHoleDistanceFromEdge
+        - obj.MagnetHoleDiameter / 2
+        - obj.MagnetEdgeThickness
+        - obj.SmallFillet
+    )
     smfillins = inframedis - obj.SmallFillet
-    bigfillpos =obj.GridSize/2 - obj.MagnetHoleDistanceFromEdge - (obj.MagnetHoleDiameter/2+obj.MagnetEdgeThickness) * math.sin(math.pi/4)
+    bigfillpos = (
+        obj.GridSize / 2
+        - obj.MagnetHoleDistanceFromEdge
+        - (obj.MagnetHoleDiameter / 2 + obj.MagnetEdgeThickness) * math.sin(math.pi / 4)
+    )
 
+    V1 = App.Vector(-smfilloffcen, -inframedis, 0)
+    V2 = App.Vector(-magedge, -smfillins, 0)
+    V3 = App.Vector(-magedge, -magcenter, 0)
+    V4 = App.Vector(-magcenter, -magedge, 0)
+    V5 = App.Vector(-smfillins, -magedge, 0)
+    V6 = App.Vector(-inframedis, -smfilloffcen, 0)
 
-    V1 = App.Vector(-smfilloffcen,-inframedis,0)
-    V2 = App.Vector(-magedge,-smfillins,0)
-    V3 = App.Vector(-magedge,-magcenter,0)
-    V4 = App.Vector(-magcenter,-magedge,0)
-    V5 = App.Vector(-smfillins,-magedge,0)
-    V6 = App.Vector(-inframedis,-smfilloffcen,0)
+    VA1 = App.Vector(-smfillposmag, -smfillpos, 0)
+    VA2 = App.Vector(-bigfillpos, -bigfillpos, 0)
+    VA3 = App.Vector(-smfillpos, -smfillposmag, 0)
 
-    VA1 = App.Vector(-smfillposmag,-smfillpos,0)
-    VA2 = App.Vector(-bigfillpos,-bigfillpos,0)
-    VA3 = App.Vector(-smfillpos,-smfillposmag,0)
+    V7 = App.Vector(-inframedis, smfilloffcen, 0)
+    V8 = App.Vector(-smfillins, magedge, 0)
+    V9 = App.Vector(-magcenter, magedge, 0)
+    V10 = App.Vector(-magedge, magcenter, 0)
+    V11 = App.Vector(-magedge, smfillins, 0)
+    V12 = App.Vector(-smfilloffcen, inframedis, 0)
 
-    V7 = App.Vector(-inframedis,smfilloffcen,0)
-    V8 = App.Vector(-smfillins,magedge,0)
-    V9 = App.Vector(-magcenter,magedge,0)
-    V10 = App.Vector(-magedge,magcenter,0)
-    V11 = App.Vector(-magedge,smfillins,0)
-    V12 = App.Vector(-smfilloffcen,inframedis,0)
+    VA4 = App.Vector(-smfillpos, smfillposmag, 0)
+    VA5 = App.Vector(-bigfillpos, bigfillpos, 0)
+    VA6 = App.Vector(-smfillposmag, smfillpos, 0)
 
-    VA4 = App.Vector(-smfillpos,smfillposmag,0)
-    VA5 = App.Vector(-bigfillpos,bigfillpos,0)
-    VA6 = App.Vector(-smfillposmag,smfillpos,0)
+    V13 = App.Vector(smfilloffcen, inframedis, 0)
+    V14 = App.Vector(magedge, smfillins, 0)
+    V15 = App.Vector(magedge, magcenter, 0)
+    V16 = App.Vector(magcenter, magedge, 0)
+    V17 = App.Vector(smfillins, magedge, 0)
+    V18 = App.Vector(inframedis, smfilloffcen, 0)
 
-    V13 = App.Vector(smfilloffcen,inframedis,0)
-    V14= App.Vector(magedge,smfillins,0)
-    V15= App.Vector(magedge,magcenter,0)
-    V16= App.Vector(magcenter,magedge,0)
-    V17= App.Vector(smfillins,magedge,0)
-    V18= App.Vector(inframedis,smfilloffcen,0)
+    VA7 = App.Vector(smfillposmag, smfillpos, 0)
+    VA8 = App.Vector(bigfillpos, bigfillpos, 0)
+    VA9 = App.Vector(smfillpos, smfillposmag, 0)
 
-    VA7 = App.Vector(smfillposmag,smfillpos,0)
-    VA8 = App.Vector(bigfillpos, bigfillpos,0)
-    VA9 = App.Vector(smfillpos,smfillposmag,0)
+    V19 = App.Vector(inframedis, -smfilloffcen, 0)
+    V20 = App.Vector(smfillins, -magedge, 0)
+    V21 = App.Vector(magcenter, -magedge, 0)
+    V22 = App.Vector(magedge, -magcenter, 0)
+    V23 = App.Vector(magedge, -smfillins, 0)
+    V24 = App.Vector(smfilloffcen, -inframedis, 0)
 
-    V19= App.Vector(inframedis,-smfilloffcen,0)
-    V20= App.Vector(smfillins,-magedge,0)
-    V21= App.Vector(magcenter,-magedge,0)
-    V22 = App.Vector(magedge,-magcenter,0)
-    V23= App.Vector(magedge,-smfillins,0)
-    V24 = App.Vector(smfilloffcen,-inframedis,0)
+    VA10 = App.Vector(smfillpos, -smfillposmag, 0)
+    VA11 = App.Vector(bigfillpos, -bigfillpos, 0)
+    VA12 = App.Vector(smfillposmag, -smfillpos, 0)
 
-    VA10 = App.Vector(smfillpos,-smfillposmag,0)
-    VA11= App.Vector(bigfillpos,-bigfillpos,0)
-    VA12 = App.Vector(smfillposmag,-smfillpos,0)
-
-    L1 = Part.LineSegment(V24,V1)
-    AR1 = Part.Arc(V1,VA1,V2)
-    L2 = Part.LineSegment(V2,V3)
-    AR2 = Part.Arc(V3,VA2,V4)
-    L3 = Part.LineSegment(V4,V5)
-    AR3 = Part.Arc(V5,VA3,V6)
-    L4 = Part.LineSegment(V6,V7)
-    AR4 = Part.Arc(V7,VA4,V8)
-    L5 = Part.LineSegment(V8,V9)
-    AR5 = Part.Arc(V9,VA5,V10)
-    L6 = Part.LineSegment(V10,V11)
-    AR6 = Part.Arc(V11,VA6,V12)
-    L7 = Part.LineSegment(V12,V13)
-    AR7 = Part.Arc(V13,VA7,V14)
-    L8 = Part.LineSegment(V14,V15)
-    AR8 = Part.Arc(V15,VA8,V16)
-    L9 = Part.LineSegment(V16,V17)
-    AR9 = Part.Arc(V17,VA9,V18)
-    L10 = Part.LineSegment(V18,V19)
-    AR10 = Part.Arc(V19,VA10,V20)
-    L11 = Part.LineSegment(V20,V21)
-    AR11 = Part.Arc(V21,VA11,V22)
-    L12 = Part.LineSegment(V22,V23)
-    AR12 = Part.Arc(V23,VA12,V24)
+    L1 = Part.LineSegment(V24, V1)
+    AR1 = Part.Arc(V1, VA1, V2)
+    L2 = Part.LineSegment(V2, V3)
+    AR2 = Part.Arc(V3, VA2, V4)
+    L3 = Part.LineSegment(V4, V5)
+    AR3 = Part.Arc(V5, VA3, V6)
+    L4 = Part.LineSegment(V6, V7)
+    AR4 = Part.Arc(V7, VA4, V8)
+    L5 = Part.LineSegment(V8, V9)
+    AR5 = Part.Arc(V9, VA5, V10)
+    L6 = Part.LineSegment(V10, V11)
+    AR6 = Part.Arc(V11, VA6, V12)
+    L7 = Part.LineSegment(V12, V13)
+    AR7 = Part.Arc(V13, VA7, V14)
+    L8 = Part.LineSegment(V14, V15)
+    AR8 = Part.Arc(V15, VA8, V16)
+    L9 = Part.LineSegment(V16, V17)
+    AR9 = Part.Arc(V17, VA9, V18)
+    L10 = Part.LineSegment(V18, V19)
+    AR10 = Part.Arc(V19, VA10, V20)
+    L11 = Part.LineSegment(V20, V21)
+    AR11 = Part.Arc(V21, VA11, V22)
+    L12 = Part.LineSegment(V22, V23)
+    AR12 = Part.Arc(V23, VA12, V24)
     xtranslate = zeromm
     ytranslate = zeromm
 
-    S1 = Part.Shape([L1,AR1,L2,AR2,L3,AR3,L4,AR4,L5,AR5,L6,AR6,L7,AR7,L8,AR8,L9,AR9,L10,AR10,L11,AR11,L12,AR12])
+    S1 = Part.Shape(
+        [
+            L1,
+            AR1,
+            L2,
+            AR2,
+            L3,
+            AR3,
+            L4,
+            AR4,
+            L5,
+            AR5,
+            L6,
+            AR6,
+            L7,
+            AR7,
+            L8,
+            AR8,
+            L9,
+            AR9,
+            L10,
+            AR10,
+            L11,
+            AR11,
+            L12,
+            AR12,
+        ]
+    )
 
     wire = Part.Wire(S1.Edges)
 
     face = Part.Face(wire)
 
-
-
     for x in range(obj.xGridUnits):
         ytranslate = zeromm
         for y in range(obj.yGridUnits):
 
-            HM1 = face.extrude(App.Vector(0,0,-obj.TotalHeight))
+            HM1 = face.extrude(App.Vector(0, 0, -obj.TotalHeight))
 
-            HM1.translate(App.Vector(xtranslate,ytranslate,0))
-            if y>0:
-                HM2 = Part.Solid.fuse(HM1,HM2)
+            HM1.translate(App.Vector(xtranslate, ytranslate, 0))
+            if y > 0:
+                HM2 = Part.Solid.fuse(HM1, HM2)
             else:
                 HM2 = HM1
             ytranslate += obj.GridSize
-        if x>0:
-            HM3 = Part.Solid.fuse(HM3,HM2)
+        if x > 0:
+            HM3 = Part.Solid.fuse(HM3, HM2)
         else:
             HM3 = HM2
         xtranslate += obj.GridSize
 
     return HM3
 
-def MakeBottomHoles(self, obj):
-    hole_pos = obj.GridSize/2-obj.MagnetHoleDistanceFromEdge
-    sq_bridge2_pos = -obj.GridSize/2+obj.MagnetHoleDistanceFromEdge+obj.ScrewHoleDiameter/2
 
-    sqbr1_depth = obj.MagnetHoleDepth+obj.SequentialBridgingLayerHeight
-    sqbr2_depth = obj.MagnetHoleDepth+obj.SequentialBridgingLayerHeight*2
+def MakeBottomHoles(self, obj):
+    hole_pos = obj.GridSize / 2 - obj.MagnetHoleDistanceFromEdge
+    sq_bridge2_pos = -obj.GridSize / 2 + obj.MagnetHoleDistanceFromEdge + obj.ScrewHoleDiameter / 2
+
+    sqbr1_depth = obj.MagnetHoleDepth + obj.SequentialBridgingLayerHeight
+    sqbr2_depth = obj.MagnetHoleDepth + obj.SequentialBridgingLayerHeight * 2
 
     xtranslate = zeromm
     ytranslate = zeromm
@@ -654,23 +800,41 @@ def MakeBottomHoles(self, obj):
         for x in range(obj.xGridUnits):
             ytranslate = zeromm
             for y in range(obj.yGridUnits):
-                C1 = Part.makeCylinder(obj.MagnetHoleDiameter/2, obj.MagnetHoleDepth, App.Vector(-hole_pos,-hole_pos,-obj.TotalHeight), App.Vector(0,0,1))
-                C2 = Part.makeCylinder(obj.MagnetHoleDiameter/2, obj.MagnetHoleDepth, App.Vector(hole_pos,-hole_pos,-obj.TotalHeight), App.Vector(0,0,1))
-                C3 = Part.makeCylinder(obj.MagnetHoleDiameter/2, obj.MagnetHoleDepth, App.Vector(-hole_pos,hole_pos,-obj.TotalHeight), App.Vector(0,0,1))
-                C4 = Part.makeCylinder(obj.MagnetHoleDiameter/2, obj.MagnetHoleDepth, App.Vector(hole_pos,hole_pos,-obj.TotalHeight), App.Vector(0,0,1))
+                C1 = Part.makeCylinder(
+                    obj.MagnetHoleDiameter / 2,
+                    obj.MagnetHoleDepth,
+                    App.Vector(-hole_pos, -hole_pos, -obj.TotalHeight),
+                    App.Vector(0, 0, 1),
+                )
+                C2 = Part.makeCylinder(
+                    obj.MagnetHoleDiameter / 2,
+                    obj.MagnetHoleDepth,
+                    App.Vector(hole_pos, -hole_pos, -obj.TotalHeight),
+                    App.Vector(0, 0, 1),
+                )
+                C3 = Part.makeCylinder(
+                    obj.MagnetHoleDiameter / 2,
+                    obj.MagnetHoleDepth,
+                    App.Vector(-hole_pos, hole_pos, -obj.TotalHeight),
+                    App.Vector(0, 0, 1),
+                )
+                C4 = Part.makeCylinder(
+                    obj.MagnetHoleDiameter / 2,
+                    obj.MagnetHoleDepth,
+                    App.Vector(hole_pos, hole_pos, -obj.TotalHeight),
+                    App.Vector(0, 0, 1),
+                )
 
+                HM1 = Part.Solid.multiFuse(C1, [C2, C3, C4])
 
-                HM1 = Part.Solid.multiFuse(C1,[C2,C3,C4])
-
-
-                HM1.translate(App.Vector(xtranslate,ytranslate,0))
-                if y>0:
-                    HM2 = Part.Solid.fuse(HM1,HM2)
+                HM1.translate(App.Vector(xtranslate, ytranslate, 0))
+                if y > 0:
+                    HM2 = Part.Solid.fuse(HM1, HM2)
                 else:
                     HM2 = HM1
                 ytranslate += obj.GridSize
-            if x>0:
-                HM3 = Part.Solid.fuse(HM3,HM2)
+            if x > 0:
+                HM3 = Part.Solid.fuse(HM3, HM2)
             else:
                 HM3 = HM2
             xtranslate += obj.GridSize
@@ -682,22 +846,41 @@ def MakeBottomHoles(self, obj):
         for x in range(obj.xGridUnits):
             ytranslate = zeromm
             for y in range(obj.yGridUnits):
-                CS1 = Part.makeCylinder(obj.ScrewHoleDiameter/2, obj.ScrewHoleDepth, App.Vector(-hole_pos,-hole_pos,-obj.TotalHeight), App.Vector(0,0,1))
-                CS2 = Part.makeCylinder(obj.ScrewHoleDiameter/2, obj.ScrewHoleDepth, App.Vector(hole_pos,-hole_pos,-obj.TotalHeight), App.Vector(0,0,1))
-                CS3 = Part.makeCylinder(obj.ScrewHoleDiameter/2, obj.ScrewHoleDepth, App.Vector(-hole_pos,hole_pos,-obj.TotalHeight), App.Vector(0,0,1))
-                CS4 = Part.makeCylinder(obj.ScrewHoleDiameter/2, obj.ScrewHoleDepth, App.Vector(hole_pos,hole_pos,-obj.TotalHeight), App.Vector(0,0,1))
+                CS1 = Part.makeCylinder(
+                    obj.ScrewHoleDiameter / 2,
+                    obj.ScrewHoleDepth,
+                    App.Vector(-hole_pos, -hole_pos, -obj.TotalHeight),
+                    App.Vector(0, 0, 1),
+                )
+                CS2 = Part.makeCylinder(
+                    obj.ScrewHoleDiameter / 2,
+                    obj.ScrewHoleDepth,
+                    App.Vector(hole_pos, -hole_pos, -obj.TotalHeight),
+                    App.Vector(0, 0, 1),
+                )
+                CS3 = Part.makeCylinder(
+                    obj.ScrewHoleDiameter / 2,
+                    obj.ScrewHoleDepth,
+                    App.Vector(-hole_pos, hole_pos, -obj.TotalHeight),
+                    App.Vector(0, 0, 1),
+                )
+                CS4 = Part.makeCylinder(
+                    obj.ScrewHoleDiameter / 2,
+                    obj.ScrewHoleDepth,
+                    App.Vector(hole_pos, hole_pos, -obj.TotalHeight),
+                    App.Vector(0, 0, 1),
+                )
 
-                HM1 = Part.Solid.multiFuse(CS1,[CS2,CS3,CS4])
+                HM1 = Part.Solid.multiFuse(CS1, [CS2, CS3, CS4])
 
-
-                HM1.translate(App.Vector(xtranslate,ytranslate,0))
-                if y>0:
-                    HS2 = Part.Solid.fuse(HM1,HS2)
+                HM1.translate(App.Vector(xtranslate, ytranslate, 0))
+                if y > 0:
+                    HS2 = Part.Solid.fuse(HM1, HS2)
                 else:
                     HS2 = HM1
                 ytranslate += obj.GridSize
-            if x>0:
-                HS3 = Part.Solid.fuse(HS3,HS2)
+            if x > 0:
+                HS3 = Part.Solid.fuse(HS3, HS2)
             else:
                 HS3 = HS2
             xtranslate += obj.GridSize
@@ -708,61 +891,97 @@ def MakeBottomHoles(self, obj):
         for x in range(obj.xGridUnits):
             ytranslate = zeromm
             for y in range(obj.yGridUnits):
-                B1 = Part.makeBox(obj.ScrewHoleDiameter, obj.ScrewHoleDiameter, sqbr2_depth, App.Vector(-sq_bridge2_pos,-sq_bridge2_pos,-obj.TotalHeight), App.Vector(0,0,1))
-                B2 = Part.makeBox(obj.ScrewHoleDiameter, obj.ScrewHoleDiameter, sqbr2_depth, App.Vector(-obj.GridSize/2+obj.MagnetHoleDistanceFromEdge-obj.ScrewHoleDiameter/2,-sq_bridge2_pos,-obj.TotalHeight), App.Vector(0,0,1))
-                B3 = Part.makeBox(obj.ScrewHoleDiameter, obj.ScrewHoleDiameter, sqbr2_depth, App.Vector(-sq_bridge2_pos,-obj.GridSize/2+obj.MagnetHoleDistanceFromEdge-obj.ScrewHoleDiameter/2,-obj.TotalHeight), App.Vector(0,0,1))
-                B4 = Part.makeBox(obj.ScrewHoleDiameter, obj.ScrewHoleDiameter, sqbr2_depth, App.Vector(-obj.GridSize/2+obj.MagnetHoleDistanceFromEdge-obj.ScrewHoleDiameter/2,-obj.GridSize/2+obj.MagnetHoleDistanceFromEdge-obj.ScrewHoleDiameter/2,-obj.TotalHeight), App.Vector(0,0,1))
+                B1 = Part.makeBox(
+                    obj.ScrewHoleDiameter,
+                    obj.ScrewHoleDiameter,
+                    sqbr2_depth,
+                    App.Vector(-sq_bridge2_pos, -sq_bridge2_pos, -obj.TotalHeight),
+                    App.Vector(0, 0, 1),
+                )
+                B2 = Part.makeBox(
+                    obj.ScrewHoleDiameter,
+                    obj.ScrewHoleDiameter,
+                    sqbr2_depth,
+                    App.Vector(
+                        -obj.GridSize / 2 + obj.MagnetHoleDistanceFromEdge - obj.ScrewHoleDiameter / 2,
+                        -sq_bridge2_pos,
+                        -obj.TotalHeight,
+                    ),
+                    App.Vector(0, 0, 1),
+                )
+                B3 = Part.makeBox(
+                    obj.ScrewHoleDiameter,
+                    obj.ScrewHoleDiameter,
+                    sqbr2_depth,
+                    App.Vector(
+                        -sq_bridge2_pos,
+                        -obj.GridSize / 2 + obj.MagnetHoleDistanceFromEdge - obj.ScrewHoleDiameter / 2,
+                        -obj.TotalHeight,
+                    ),
+                    App.Vector(0, 0, 1),
+                )
+                B4 = Part.makeBox(
+                    obj.ScrewHoleDiameter,
+                    obj.ScrewHoleDiameter,
+                    sqbr2_depth,
+                    App.Vector(
+                        -obj.GridSize / 2 + obj.MagnetHoleDistanceFromEdge - obj.ScrewHoleDiameter / 2,
+                        -obj.GridSize / 2 + obj.MagnetHoleDistanceFromEdge - obj.ScrewHoleDiameter / 2,
+                        -obj.TotalHeight,
+                    ),
+                    App.Vector(0, 0, 1),
+                )
 
-                arc_pt_off_x = (math.sqrt(((obj.MagnetHoleDiameter/2)**2)-((obj.ScrewHoleDiameter/2)**2)))*unitmm
-                arc_pt_off_y = obj.ScrewHoleDiameter/2
+                arc_pt_off_x = (
+                    math.sqrt(((obj.MagnetHoleDiameter / 2) ** 2) - ((obj.ScrewHoleDiameter / 2) ** 2))
+                ) * unitmm
+                arc_pt_off_y = obj.ScrewHoleDiameter / 2
 
-                VA1 = App.Vector(hole_pos+arc_pt_off_x, hole_pos+arc_pt_off_y, -obj.TotalHeight)
-                VA2 = App.Vector(hole_pos-arc_pt_off_x, hole_pos+arc_pt_off_y, -obj.TotalHeight)
-                VA3 = App.Vector(hole_pos-arc_pt_off_x, hole_pos-arc_pt_off_y, -obj.TotalHeight)
-                VA4 = App.Vector(hole_pos+arc_pt_off_x, hole_pos-arc_pt_off_y, -obj.TotalHeight)
-                VAR1 = App.Vector(hole_pos+obj.MagnetHoleDiameter/2, hole_pos,-obj.TotalHeight)
-                VAR2 = App.Vector(hole_pos-obj.MagnetHoleDiameter/2, hole_pos,-obj.TotalHeight)
+                VA1 = App.Vector(hole_pos + arc_pt_off_x, hole_pos + arc_pt_off_y, -obj.TotalHeight)
+                VA2 = App.Vector(hole_pos - arc_pt_off_x, hole_pos + arc_pt_off_y, -obj.TotalHeight)
+                VA3 = App.Vector(hole_pos - arc_pt_off_x, hole_pos - arc_pt_off_y, -obj.TotalHeight)
+                VA4 = App.Vector(hole_pos + arc_pt_off_x, hole_pos - arc_pt_off_y, -obj.TotalHeight)
+                VAR1 = App.Vector(hole_pos + obj.MagnetHoleDiameter / 2, hole_pos, -obj.TotalHeight)
+                VAR2 = App.Vector(hole_pos - obj.MagnetHoleDiameter / 2, hole_pos, -obj.TotalHeight)
 
-                VA5 = App.Vector(-hole_pos+arc_pt_off_x, hole_pos+arc_pt_off_y, -obj.TotalHeight)
-                VA6 = App.Vector(-hole_pos-arc_pt_off_x, hole_pos+arc_pt_off_y, -obj.TotalHeight)
-                VA7 = App.Vector(-hole_pos-arc_pt_off_x, hole_pos-arc_pt_off_y, -obj.TotalHeight)
-                VA8 = App.Vector(-hole_pos+arc_pt_off_x, hole_pos-arc_pt_off_y, -obj.TotalHeight)
-                VAR3 = App.Vector(-hole_pos+obj.MagnetHoleDiameter/2, hole_pos,-obj.TotalHeight)
-                VAR4 = App.Vector(-hole_pos-obj.MagnetHoleDiameter/2, hole_pos,-obj.TotalHeight)
+                VA5 = App.Vector(-hole_pos + arc_pt_off_x, hole_pos + arc_pt_off_y, -obj.TotalHeight)
+                VA6 = App.Vector(-hole_pos - arc_pt_off_x, hole_pos + arc_pt_off_y, -obj.TotalHeight)
+                VA7 = App.Vector(-hole_pos - arc_pt_off_x, hole_pos - arc_pt_off_y, -obj.TotalHeight)
+                VA8 = App.Vector(-hole_pos + arc_pt_off_x, hole_pos - arc_pt_off_y, -obj.TotalHeight)
+                VAR3 = App.Vector(-hole_pos + obj.MagnetHoleDiameter / 2, hole_pos, -obj.TotalHeight)
+                VAR4 = App.Vector(-hole_pos - obj.MagnetHoleDiameter / 2, hole_pos, -obj.TotalHeight)
 
-                VA9 = App.Vector(hole_pos+arc_pt_off_x, -hole_pos+arc_pt_off_y, -obj.TotalHeight)
-                VA10 = App.Vector(hole_pos-arc_pt_off_x, -hole_pos+arc_pt_off_y, -obj.TotalHeight)
-                VA11= App.Vector(hole_pos-arc_pt_off_x, -hole_pos-arc_pt_off_y, -obj.TotalHeight)
-                VA12= App.Vector(hole_pos+arc_pt_off_x, -hole_pos-arc_pt_off_y, -obj.TotalHeight)
-                VAR5 = App.Vector(hole_pos+obj.MagnetHoleDiameter/2, -hole_pos,-obj.TotalHeight)
-                VAR6 = App.Vector(hole_pos-obj.MagnetHoleDiameter/2, -hole_pos,-obj.TotalHeight)
+                VA9 = App.Vector(hole_pos + arc_pt_off_x, -hole_pos + arc_pt_off_y, -obj.TotalHeight)
+                VA10 = App.Vector(hole_pos - arc_pt_off_x, -hole_pos + arc_pt_off_y, -obj.TotalHeight)
+                VA11 = App.Vector(hole_pos - arc_pt_off_x, -hole_pos - arc_pt_off_y, -obj.TotalHeight)
+                VA12 = App.Vector(hole_pos + arc_pt_off_x, -hole_pos - arc_pt_off_y, -obj.TotalHeight)
+                VAR5 = App.Vector(hole_pos + obj.MagnetHoleDiameter / 2, -hole_pos, -obj.TotalHeight)
+                VAR6 = App.Vector(hole_pos - obj.MagnetHoleDiameter / 2, -hole_pos, -obj.TotalHeight)
 
-                VA13 = App.Vector(-hole_pos+arc_pt_off_x, -hole_pos+arc_pt_off_y, -obj.TotalHeight)
-                VA14= App.Vector(-hole_pos-arc_pt_off_x, -hole_pos+arc_pt_off_y, -obj.TotalHeight)
-                VA15= App.Vector(-hole_pos-arc_pt_off_x, -hole_pos-arc_pt_off_y, -obj.TotalHeight)
-                VA16= App.Vector(-hole_pos+arc_pt_off_x, -hole_pos-arc_pt_off_y, -obj.TotalHeight)
-                VAR7 = App.Vector(-hole_pos+obj.MagnetHoleDiameter/2, -hole_pos,-obj.TotalHeight)
-                VAR8 = App.Vector(-hole_pos-obj.MagnetHoleDiameter/2, -hole_pos,-obj.TotalHeight)
+                VA13 = App.Vector(-hole_pos + arc_pt_off_x, -hole_pos + arc_pt_off_y, -obj.TotalHeight)
+                VA14 = App.Vector(-hole_pos - arc_pt_off_x, -hole_pos + arc_pt_off_y, -obj.TotalHeight)
+                VA15 = App.Vector(-hole_pos - arc_pt_off_x, -hole_pos - arc_pt_off_y, -obj.TotalHeight)
+                VA16 = App.Vector(-hole_pos + arc_pt_off_x, -hole_pos - arc_pt_off_y, -obj.TotalHeight)
+                VAR7 = App.Vector(-hole_pos + obj.MagnetHoleDiameter / 2, -hole_pos, -obj.TotalHeight)
+                VAR8 = App.Vector(-hole_pos - obj.MagnetHoleDiameter / 2, -hole_pos, -obj.TotalHeight)
 
+                L1 = Part.LineSegment(VA1, VA2)
+                L2 = Part.LineSegment(VA3, VA4)
+                L3 = Part.LineSegment(VA5, VA6)
+                L4 = Part.LineSegment(VA7, VA8)
+                L5 = Part.LineSegment(VA9, VA10)
+                L6 = Part.LineSegment(VA11, VA12)
+                L7 = Part.LineSegment(VA13, VA14)
+                L8 = Part.LineSegment(VA15, VA16)
 
-                L1 = Part.LineSegment(VA1,VA2)
-                L2 = Part.LineSegment(VA3,VA4)
-                L3 = Part.LineSegment(VA5,VA6)
-                L4 = Part.LineSegment(VA7,VA8)
-                L5 = Part.LineSegment(VA9,VA10)
-                L6 = Part.LineSegment(VA11,VA12)
-                L7 = Part.LineSegment(VA13,VA14)
-                L8 = Part.LineSegment(VA15,VA16)
-
-
-                AR1 = Part.Arc(VA1,VAR1,VA4)
-                AR2 = Part.Arc(VA2,VAR2,VA3)
-                AR3 = Part.Arc(VA5,VAR3,VA8)
-                AR4 = Part.Arc(VA6,VAR4,VA7)
-                AR5 = Part.Arc(VA9,VAR5,VA12)
-                AR6 = Part.Arc(VA10,VAR6,VA11)
-                AR7 = Part.Arc(VA13,VAR7,VA16)
-                AR8 = Part.Arc(VA14,VAR8,VA15)
+                AR1 = Part.Arc(VA1, VAR1, VA4)
+                AR2 = Part.Arc(VA2, VAR2, VA3)
+                AR3 = Part.Arc(VA5, VAR3, VA8)
+                AR4 = Part.Arc(VA6, VAR4, VA7)
+                AR5 = Part.Arc(VA9, VAR5, VA12)
+                AR6 = Part.Arc(VA10, VAR6, VA11)
+                AR7 = Part.Arc(VA13, VAR7, VA16)
+                AR8 = Part.Arc(VA14, VAR8, VA15)
 
                 S1 = Part.Shape([L1, AR1, AR2, L2])
                 S2 = Part.Shape([L3, AR3, AR4, L4])
@@ -775,29 +994,27 @@ def MakeBottomHoles(self, obj):
                 w4 = Part.Wire(S4.Edges)
 
                 sq1_1 = Part.Face(w1)
-                sq1_1 = sq1_1.extrude(App.Vector(0,0,sqbr1_depth))
+                sq1_1 = sq1_1.extrude(App.Vector(0, 0, sqbr1_depth))
 
                 sq1_2 = Part.Face(w2)
-                sq1_2 = sq1_2.extrude(App.Vector(0,0,sqbr1_depth))
+                sq1_2 = sq1_2.extrude(App.Vector(0, 0, sqbr1_depth))
 
                 sq1_3 = Part.Face(w3)
-                sq1_3 = sq1_3.extrude(App.Vector(0,0,sqbr1_depth))
+                sq1_3 = sq1_3.extrude(App.Vector(0, 0, sqbr1_depth))
 
                 sq1_4 = Part.Face(w4)
-                sq1_4 = sq1_4.extrude(App.Vector(0,0,sqbr1_depth))
+                sq1_4 = sq1_4.extrude(App.Vector(0, 0, sqbr1_depth))
 
+                HM1 = Part.Solid.multiFuse(sq1_1, [B1, B2, B3, B4, sq1_2, sq1_3, sq1_4])
 
-                HM1 = Part.Solid.multiFuse(sq1_1,[B1,B2,B3,B4,sq1_2,sq1_3,sq1_4])
-
-
-                HM1.translate(App.Vector(xtranslate,ytranslate,0))
-                if y>0:
-                    HSQ2 = Part.Solid.fuse(HM1,HSQ2)
+                HM1.translate(App.Vector(xtranslate, ytranslate, 0))
+                if y > 0:
+                    HSQ2 = Part.Solid.fuse(HM1, HSQ2)
                 else:
                     HSQ2 = HM1
                 ytranslate += obj.GridSize
-            if x>0:
-                HSQ3 = Part.Solid.fuse(HSQ3,HSQ2)
+            if x > 0:
+                HSQ3 = Part.Solid.fuse(HSQ3, HSQ2)
             else:
                 HSQ3 = HSQ2
             xtranslate += obj.GridSize
@@ -807,37 +1024,47 @@ def MakeBottomHoles(self, obj):
     if obj.MagnetHoles and not obj.ScrewHoles:
         fusetotal = HM3
     if obj.ScrewHoles and obj.MagnetHoles:
-        fusetotal = Part.Solid.multiFuse(HM3,[HS3,HSQ3])
+        fusetotal = Part.Solid.multiFuse(HM3, [HS3, HSQ3])
 
     return fusetotal
 
+
 def MakeEcoBinCut(self, obj):
 
-    func_fuse= RoundedRectangleExtrude(obj.xTotalWidth-obj.WallThickness*2, obj.yTotalWidth-obj.WallThickness*2, -obj.TotalHeight + obj.BaseProfileHeight + obj.BaseWallThickness, obj.TotalHeight - obj.BaseProfileHeight - obj.BaseWallThickness, obj.BinOuterRadius-obj.WallThickness)
-    func_fuse.translate(App.Vector(obj.xTotalWidth/2-obj.BinUnit/2,obj.yTotalWidth/2-obj.BinUnit/2,0))
+    func_fuse = RoundedRectangleExtrude(
+        obj.xTotalWidth - obj.WallThickness * 2,
+        obj.yTotalWidth - obj.WallThickness * 2,
+        -obj.TotalHeight + obj.BaseProfileHeight + obj.BaseWallThickness,
+        obj.TotalHeight - obj.BaseProfileHeight - obj.BaseWallThickness,
+        obj.BinOuterRadius - obj.WallThickness,
+    )
+    func_fuse.translate(App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0))
 
-    base_offset = obj.BaseWallThickness * math.tan(math.pi/8)
-    bt_cmf_width = obj.BinUnit - 2*obj.BaseProfileTopChamfer - obj.BaseWallThickness*2 - 0.4*unitmm*2
-    vert_width = obj.BinUnit - 2*obj.BaseProfileTopChamfer - obj.BaseWallThickness*2
-    bt_chf_rad = obj.BinVerticalRadius - 0.4*unitmm - obj.BaseWallThickness
+    base_offset = obj.BaseWallThickness * math.tan(math.pi / 8)
+    bt_cmf_width = obj.BinUnit - 2 * obj.BaseProfileTopChamfer - obj.BaseWallThickness * 2 - 0.4 * unitmm * 2
+    vert_width = obj.BinUnit - 2 * obj.BaseProfileTopChamfer - obj.BaseWallThickness * 2
+    bt_chf_rad = obj.BinVerticalRadius - 0.4 * unitmm - obj.BaseWallThickness
     v_chf_rad = obj.BinVerticalRadius - obj.BaseWallThickness
 
     if obj.MagnetHoles:
         magoffset = obj.MagnetHoleDepth
-        if (obj.MagnetHoleDepth+obj.BaseWallThickness) > (obj.BaseProfileBottomChamfer+obj.BaseProfileVerticalSection+base_offset):
-            tp_chf_offset = (obj.MagnetHoleDepth+obj.BaseWallThickness) - (obj.BaseProfileBottomChamfer+obj.BaseProfileVerticalSection+base_offset)
+        if (obj.MagnetHoleDepth + obj.BaseWallThickness) > (
+            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + base_offset
+        ):
+            tp_chf_offset = (obj.MagnetHoleDepth + obj.BaseWallThickness) - (
+                obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + base_offset
+            )
         else:
-            tp_chf_offset = 0*unitmm
+            tp_chf_offset = 0 * unitmm
     else:
-        magoffset = 0*unitmm
-        tp_chf_offset = 0*unitmm
+        magoffset = 0 * unitmm
+        tp_chf_offset = 0 * unitmm
 
-    if bt_chf_rad <= 0.01 :
-        bt_chf_rad = 0.01*unitmm
+    if bt_chf_rad <= 0.01:
+        bt_chf_rad = 0.01 * unitmm
 
-    if v_chf_rad <= 0.01 :
-        v_chf_rad = 0.01*unitmm
-
+    if v_chf_rad <= 0.01:
+        v_chf_rad = 0.01 * unitmm
 
     xtranslate = zeromm
     ytranslate = zeromm
@@ -846,69 +1073,118 @@ def MakeEcoBinCut(self, obj):
         ytranslate = zeromm
         for y in range(obj.yGridUnits):
 
-            bottom_chamfer = RoundedRectangleChamfer(bt_cmf_width, bt_cmf_width, -obj.TotalHeight + obj.BaseWallThickness + magoffset,0.4*unitmm, bt_chf_rad)
+            bottom_chamfer = RoundedRectangleChamfer(
+                bt_cmf_width,
+                bt_cmf_width,
+                -obj.TotalHeight + obj.BaseWallThickness + magoffset,
+                0.4 * unitmm,
+                bt_chf_rad,
+            )
 
-            vertical_section = RoundedRectangleExtrude(vert_width, vert_width, -obj.TotalHeight + obj.BaseWallThickness + 0.4*unitmm + magoffset, obj.BaseProfileVerticalSection + obj.BaseProfileBottomChamfer + base_offset - obj.BaseWallThickness - 0.4*unitmm, v_chf_rad)
-            assembly = Part.Shape.fuse(bottom_chamfer,vertical_section)
+            vertical_section = RoundedRectangleExtrude(
+                vert_width,
+                vert_width,
+                -obj.TotalHeight + obj.BaseWallThickness + 0.4 * unitmm + magoffset,
+                obj.BaseProfileVerticalSection
+                + obj.BaseProfileBottomChamfer
+                + base_offset
+                - obj.BaseWallThickness
+                - 0.4 * unitmm,
+                v_chf_rad,
+            )
+            assembly = Part.Shape.fuse(bottom_chamfer, vertical_section)
 
-            top_chamfer = RoundedRectangleChamfer(vert_width+tp_chf_offset, vert_width+tp_chf_offset, -obj.TotalHeight + obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + base_offset+tp_chf_offset, obj.BaseProfileTopChamfer+ obj.BaseWallThickness - tp_chf_offset, v_chf_rad)
-            assembly = Part.Solid.fuse(assembly,top_chamfer)
+            top_chamfer = RoundedRectangleChamfer(
+                vert_width + tp_chf_offset,
+                vert_width + tp_chf_offset,
+                -obj.TotalHeight
+                + obj.BaseProfileBottomChamfer
+                + obj.BaseProfileVerticalSection
+                + base_offset
+                + tp_chf_offset,
+                obj.BaseProfileTopChamfer + obj.BaseWallThickness - tp_chf_offset,
+                v_chf_rad,
+            )
+            assembly = Part.Solid.fuse(assembly, top_chamfer)
 
-
-            assembly.translate(App.Vector(xtranslate,ytranslate,0))
-            if y>0:
-                totalassembly1 = Part.Solid.fuse(assembly,totalassembly1)
+            assembly.translate(App.Vector(xtranslate, ytranslate, 0))
+            if y > 0:
+                totalassembly1 = Part.Solid.fuse(assembly, totalassembly1)
             else:
                 totalassembly1 = assembly
             ytranslate += obj.GridSize
-        if x>0:
-            totalassembly2 = Part.Solid.fuse(totalassembly2,totalassembly1)
+        if x > 0:
+            totalassembly2 = Part.Solid.fuse(totalassembly2, totalassembly1)
         else:
             totalassembly2 = totalassembly1
         xtranslate += obj.GridSize
 
     func_fuse = func_fuse.fuse(totalassembly2)
 
-    outer_trim1= RoundedRectangleExtrude(obj.xTotalWidth-obj.WallThickness*2, obj.yTotalWidth-obj.WallThickness*2, -obj.TotalHeight, obj.TotalHeight, obj.BinOuterRadius-obj.WallThickness)
-    outer_trim1.translate(App.Vector(obj.xTotalWidth/2-obj.BinUnit/2,obj.yTotalWidth/2-obj.BinUnit/2,0))
+    outer_trim1 = RoundedRectangleExtrude(
+        obj.xTotalWidth - obj.WallThickness * 2,
+        obj.yTotalWidth - obj.WallThickness * 2,
+        -obj.TotalHeight,
+        obj.TotalHeight,
+        obj.BinOuterRadius - obj.WallThickness,
+    )
+    outer_trim1.translate(App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0))
 
-    outer_trim2= RoundedRectangleExtrude(obj.xTotalWidth+20*unitmm, obj.yTotalWidth+20*unitmm, -obj.TotalHeight , obj.TotalHeight - obj.BaseProfileHeight, obj.BinOuterRadius)
-    outer_trim2.translate(App.Vector(obj.xTotalWidth/2-obj.BinUnit/2,obj.yTotalWidth/2-obj.BinUnit/2,0))
+    outer_trim2 = RoundedRectangleExtrude(
+        obj.xTotalWidth + 20 * unitmm,
+        obj.yTotalWidth + 20 * unitmm,
+        -obj.TotalHeight,
+        obj.TotalHeight - obj.BaseProfileHeight,
+        obj.BinOuterRadius,
+    )
+    outer_trim2.translate(App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0))
 
-    outer_trim2= outer_trim2.cut(outer_trim1)
+    outer_trim2 = outer_trim2.cut(outer_trim1)
 
     func_fuse = func_fuse.cut(outer_trim2)
     # Dividers
 
-    xcomp_w = (obj.xTotalWidth-obj.WallThickness*2-obj.xDividers*obj.DividerThickness)/(obj.xDividers+1)
-    ycomp_w = (obj.yTotalWidth-obj.WallThickness*2-obj.yDividers*obj.DividerThickness)/(obj.yDividers+1)
+    xcomp_w = (obj.xTotalWidth - obj.WallThickness * 2 - obj.xDividers * obj.DividerThickness) / (obj.xDividers + 1)
+    ycomp_w = (obj.yTotalWidth - obj.WallThickness * 2 - obj.yDividers * obj.DividerThickness) / (obj.yDividers + 1)
 
-    xdivheight = obj.xDividerHeight if obj.xDividerHeight !=0 else obj.TotalHeight
-    ydivheight = obj.yDividerHeight if obj.yDividerHeight !=0 else obj.TotalHeight
+    xdivheight = obj.xDividerHeight if obj.xDividerHeight != 0 else obj.TotalHeight
+    ydivheight = obj.yDividerHeight if obj.yDividerHeight != 0 else obj.TotalHeight
 
     xtranslate = zeromm + xcomp_w + obj.WallThickness - obj.DividerThickness
     ytranslate = zeromm + ycomp_w + obj.WallThickness
 
     # dividers in x direction
     for x in range(obj.xDividers):
-        comp = Part.makeBox(obj.DividerThickness,obj.yTotalWidth,xdivheight,App.Vector(-obj.BinUnit/2+obj.DividerThickness,-obj.BinUnit/2,-obj.TotalHeight),App.Vector(0,0,1))
-        comp.translate(App.Vector(xtranslate,0,0))
-        if x>0:
+        comp = Part.makeBox(
+            obj.DividerThickness,
+            obj.yTotalWidth,
+            xdivheight,
+            App.Vector(-obj.BinUnit / 2 + obj.DividerThickness, -obj.BinUnit / 2, -obj.TotalHeight),
+            App.Vector(0, 0, 1),
+        )
+        comp.translate(App.Vector(xtranslate, 0, 0))
+        if x > 0:
             xdiv = xdiv.fuse(comp)
 
         else:
             xdiv = comp
-        xtranslate += xcomp_w+obj.DividerThickness
+        xtranslate += xcomp_w + obj.DividerThickness
 
     # dividers in y direction
     for y in range(obj.yDividers):
-        comp = Part.makeBox(obj.xTotalWidth,obj.DividerThickness,ydivheight,App.Vector(-obj.BinUnit/2,-obj.BinUnit/2,-obj.TotalHeight),App.Vector(0,0,1))
-        comp.translate(App.Vector(0,ytranslate,0))
-        if y>0:
+        comp = Part.makeBox(
+            obj.xTotalWidth,
+            obj.DividerThickness,
+            ydivheight,
+            App.Vector(-obj.BinUnit / 2, -obj.BinUnit / 2, -obj.TotalHeight),
+            App.Vector(0, 0, 1),
+        )
+        comp.translate(App.Vector(0, ytranslate, 0))
+        if y > 0:
             ydiv = ydiv.fuse(comp)
         else:
             ydiv = comp
-        ytranslate += ycomp_w+obj.DividerThickness
+        ytranslate += ycomp_w + obj.DividerThickness
 
     if obj.xDividers > 0:
         func_fuse = func_fuse.cut(xdiv)
@@ -916,7 +1192,7 @@ def MakeEcoBinCut(self, obj):
         func_fuse = func_fuse.cut(ydiv)
     b_edges = []
 
-    divfil = -obj.TotalHeight + obj.BaseProfileHeight + obj.BaseWallThickness + 1*unitmm
+    divfil = -obj.TotalHeight + obj.BaseProfileHeight + obj.BaseWallThickness + 1 * unitmm
     for idx_edge, edge in enumerate(func_fuse.Edges):
         z0 = edge.Vertexes[0].Point.z
         z1 = edge.Vertexes[1].Point.z

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -794,6 +794,10 @@ def MakeBottomHoles(self, obj):
     sqbr1_depth = obj.MagnetHoleDepth + obj.SequentialBridgingLayerHeight
     sqbr2_depth = obj.MagnetHoleDepth + obj.SequentialBridgingLayerHeight * 2
 
+    # This could be sped up if by creating copies of Solids and moving those.
+    # Create 1 hole, copy it 3x and move it to the correct position.
+    # Then create copies of the fused 4 holes and move them to the correct position per row & col.
+
     xtranslate = zeromm
     ytranslate = zeromm
     if obj.MagnetHoles:

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -47,7 +47,9 @@ def createRoundedRectangle(xwidth, ywidth, zsketchplane, radius):
 
 def RoundedRectangleChamfer(xwidth, ywidth, zsketchplane, height, radius):
     w1 = createRoundedRectangle(xwidth, ywidth, zsketchplane, radius)
-    w2 = createRoundedRectangle(xwidth + 2 * height, ywidth + 2 * height, zsketchplane + height, radius + height)
+    w2 = createRoundedRectangle(
+        xwidth + 2 * height, ywidth + 2 * height, zsketchplane + height, radius + height
+    )
     wires = [w1, w2]
     return Part.makeLoft(wires, True)
 
@@ -59,7 +61,6 @@ def RoundedRectangleExtrude(xwidth, ywidth, zsketchplane, height, radius):
 
 
 def MakeLabelShelf(self, obj):
-
     towall = -obj.BinUnit / 2 + obj.WallThickness
     tolabelend = (
         -obj.BinUnit / 2
@@ -79,8 +80,12 @@ def MakeLabelShelf(self, obj):
     fwoverride = False
     xdiv = obj.xDividers + 1
     ydiv = obj.yDividers + 1
-    xcompwidth = (obj.xTotalWidth - obj.WallThickness * 2 - obj.DividerThickness * obj.xDividers) / (xdiv)
-    ycompwidth = (obj.yTotalWidth - obj.WallThickness * 2 - obj.DividerThickness * obj.yDividers) / (ydiv)
+    xcompwidth = (
+        obj.xTotalWidth - obj.WallThickness * 2 - obj.DividerThickness * obj.xDividers
+    ) / (xdiv)
+    ycompwidth = (
+        obj.yTotalWidth - obj.WallThickness * 2 - obj.DividerThickness * obj.yDividers
+    ) / (ydiv)
 
     V1 = App.Vector(towall, 0, 0)
     V2 = App.Vector(tolabelend, 0, 0)
@@ -102,13 +107,11 @@ def MakeLabelShelf(self, obj):
         fwoverride = True
 
     if obj.LabelShelfPlacement == "Full Width" or fwoverride:
-
         fw = obj.yTotalWidth - obj.WallThickness * 2
         ytranslate = -obj.BinUnit / 2 + obj.WallThickness
         xtranslate = zeromm
         parts = []
         for x in range(xdiv):
-
             ls = face.extrude(App.Vector(0, fw, 0))
 
             ls.translate(App.Vector(xtranslate, ytranslate, 0))
@@ -144,21 +147,27 @@ def MakeLabelShelf(self, obj):
                 z0 = edge.Vertexes[0].Point.z
                 z1 = edge.Vertexes[1].Point.z
 
-                if z0 == -obj.LabelShelfVerticalThickness and z1 == -obj.LabelShelfVerticalThickness:
+                if (
+                    z0 == -obj.LabelShelfVerticalThickness
+                    and z1 == -obj.LabelShelfVerticalThickness
+                ):
                     h_edges.append(edge)
 
             funcfuse = funcfuse.makeFillet(obj.InsideFilletRadius, h_edges)
 
     if obj.LabelShelfPlacement == "Center" and not fwoverride:
-
         xtranslate = zeromm
-        ysp = -obj.BinUnit / 2 + obj.WallThickness + ycompwidth / 2 - obj.LabelShelfLength / 2
+        ysp = (
+            -obj.BinUnit / 2
+            + obj.WallThickness
+            + ycompwidth / 2
+            - obj.LabelShelfLength / 2
+        )
         ytranslate = ysp
         parts = []
         for x in range(xdiv):
             ytranslate = ysp
             for y in range(ydiv):
-
                 ls = face.extrude(App.Vector(0, obj.LabelShelfLength, 0))
 
                 ls.translate(App.Vector(xtranslate, ytranslate, 0))
@@ -183,7 +192,10 @@ def MakeLabelShelf(self, obj):
                 z0 = edge.Vertexes[0].Point.z
                 z1 = edge.Vertexes[1].Point.z
 
-                if z0 == -obj.LabelShelfVerticalThickness and z1 == -obj.LabelShelfVerticalThickness:
+                if (
+                    z0 == -obj.LabelShelfVerticalThickness
+                    and z1 == -obj.LabelShelfVerticalThickness
+                ):
                     h_edges.append(edge)
 
             funcfuse = funcfuse.makeFillet(obj.InsideFilletRadius, h_edges)
@@ -196,7 +208,6 @@ def MakeLabelShelf(self, obj):
         for x in range(xdiv):
             ytranslate = ysp
             for y in range(ydiv):
-
                 ls = face.extrude(App.Vector(0, obj.LabelShelfLength, 0))
 
                 ls.translate(App.Vector(xtranslate, ytranslate, 0))
@@ -234,7 +245,10 @@ def MakeLabelShelf(self, obj):
                 z0 = edge.Vertexes[0].Point.z
                 z1 = edge.Vertexes[1].Point.z
 
-                if z0 == -obj.LabelShelfVerticalThickness and z1 == -obj.LabelShelfVerticalThickness:
+                if (
+                    z0 == -obj.LabelShelfVerticalThickness
+                    and z1 == -obj.LabelShelfVerticalThickness
+                ):
                     h_edges.append(edge)
 
             funcfuse = funcfuse.makeFillet(obj.InsideFilletRadius, h_edges)
@@ -247,7 +261,6 @@ def MakeLabelShelf(self, obj):
         for x in range(xdiv):
             ytranslate = ysp
             for y in range(ydiv):
-
                 ls = face.extrude(App.Vector(0, obj.LabelShelfLength, 0))
 
                 ls.translate(App.Vector(xtranslate, ytranslate, 0))
@@ -286,7 +299,10 @@ def MakeLabelShelf(self, obj):
                 z0 = edge.Vertexes[0].Point.z
                 z1 = edge.Vertexes[1].Point.z
 
-                if z0 == -obj.LabelShelfVerticalThickness and z1 == -obj.LabelShelfVerticalThickness:
+                if (
+                    z0 == -obj.LabelShelfVerticalThickness
+                    and z1 == -obj.LabelShelfVerticalThickness
+                ):
                     h_edges.append(edge)
 
             funcfuse = funcfuse.makeFillet(obj.InsideFilletRadius, h_edges)
@@ -299,7 +315,9 @@ def MakeScoop(self, obj):
     scooprad2 = obj.ScoopRadius + 1 * unitmm
     scooprad3 = obj.ScoopRadius + 1 * unitmm
 
-    xcomp_w = (obj.xTotalWidth - obj.WallThickness * 2 - obj.xDividers * obj.DividerThickness) / (obj.xDividers + 1)
+    xcomp_w = (
+        obj.xTotalWidth - obj.WallThickness * 2 - obj.xDividers * obj.DividerThickness
+    ) / (obj.xDividers + 1)
 
     xdivscoop = obj.xDividerHeight - obj.HeightUnitValue
 
@@ -313,18 +331,34 @@ def MakeScoop(self, obj):
     scooprad = min(obj.ScoopRadius, scooprad1, scooprad2, scooprad3)
 
     if scooprad <= 0:
-        App.Console.PrintMessage("scooop could not be made due to bin selected parameters\n")
+        App.Console.PrintMessage(
+            "scooop could not be made due to bin selected parameters\n"
+        )
         return
 
-    V1 = App.Vector(obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness, 0, -obj.UsableHeight + scooprad)
-    V2 = App.Vector(obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness, 0, -obj.UsableHeight)
-    V3 = App.Vector(obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness - scooprad, 0, -obj.UsableHeight)
+    V1 = App.Vector(
+        obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness,
+        0,
+        -obj.UsableHeight + scooprad,
+    )
+    V2 = App.Vector(
+        obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness, 0, -obj.UsableHeight
+    )
+    V3 = App.Vector(
+        obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness - scooprad,
+        0,
+        -obj.UsableHeight,
+    )
 
     L1 = Part.LineSegment(V1, V2)
     L2 = Part.LineSegment(V2, V3)
 
     VC1 = App.Vector(
-        obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness - scooprad + scooprad * math.sin(math.pi / 4),
+        obj.xTotalWidth
+        - obj.BinUnit / 2
+        - obj.WallThickness
+        - scooprad
+        + scooprad * math.sin(math.pi / 4),
         0,
         -obj.UsableHeight + scooprad - scooprad * math.sin(math.pi / 4),
     )
@@ -345,20 +379,31 @@ def MakeScoop(self, obj):
         + obj.StackingLipTopChamfer
         + obj.StackingLipBottomChamfer
     )
-    compwidth = (obj.xTotalWidth - obj.WallThickness * 2 - obj.DividerThickness * obj.xDividers) / (xdiv)
+    compwidth = (
+        obj.xTotalWidth - obj.WallThickness * 2 - obj.DividerThickness * obj.xDividers
+    ) / (xdiv)
 
     scoopbox = Part.makeBox(
-        obj.StackingLipBottomChamfer + obj.StackingLipTopChamfer + obj.StackingLipTopLedge - obj.WallThickness,
+        obj.StackingLipBottomChamfer
+        + obj.StackingLipTopChamfer
+        + obj.StackingLipTopLedge
+        - obj.WallThickness,
         obj.yTotalWidth - obj.WallThickness * 2,
         obj.UsableHeight,
-        App.Vector(obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness, -obj.BinUnit / 2 + obj.WallThickness, 0),
+        App.Vector(
+            obj.xTotalWidth - obj.BinUnit / 2 - obj.WallThickness,
+            -obj.BinUnit / 2 + obj.WallThickness,
+            0,
+        ),
         App.Vector(0, 0, -1),
     )
 
     parts = []
     for x in range(xdiv):
         scoop = face.extrude(App.Vector(0, obj.yTotalWidth - obj.WallThickness * 2, 0))
-        scoop.translate(App.Vector(-xtranslate, -obj.BinUnit / 2 + obj.WallThickness, 0))
+        scoop.translate(
+            App.Vector(-xtranslate, -obj.BinUnit / 2 + obj.WallThickness, 0)
+        )
 
         if x > 0:
             xtranslate += compwidth + obj.DividerThickness
@@ -404,19 +449,30 @@ def MakeScoop(self, obj):
 
 
 def MakeStackingLip(self, obj):
-
-    stacking_lip_path = createRoundedRectangle(obj.xTotalWidth, obj.yTotalWidth, 0, obj.BinOuterRadius)
+    stacking_lip_path = createRoundedRectangle(
+        obj.xTotalWidth, obj.yTotalWidth, 0, obj.BinOuterRadius
+    )
     stacking_lip_path.translate(
-        App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0)
+        App.Vector(
+            obj.xTotalWidth / 2 - obj.BinUnit / 2,
+            obj.yTotalWidth / 2 - obj.BinUnit / 2,
+            0,
+        )
     )
     ST1 = App.Vector(-obj.BinUnit / 2, 0, 0)
     ST2 = App.Vector(
-        -obj.BinUnit / 2, 0, obj.StackingLipBottomChamfer + obj.StackingLipVerticalSection + obj.StackingLipTopChamfer
+        -obj.BinUnit / 2,
+        0,
+        obj.StackingLipBottomChamfer
+        + obj.StackingLipVerticalSection
+        + obj.StackingLipTopChamfer,
     )
     ST3 = App.Vector(
         -obj.BinUnit / 2 + obj.StackingLipTopLedge,
         0,
-        obj.StackingLipBottomChamfer + obj.StackingLipVerticalSection + obj.StackingLipTopChamfer,
+        obj.StackingLipBottomChamfer
+        + obj.StackingLipVerticalSection
+        + obj.StackingLipTopChamfer,
     )
     ST4 = App.Vector(
         -obj.BinUnit / 2 + obj.StackingLipTopLedge + obj.StackingLipTopChamfer,
@@ -424,13 +480,23 @@ def MakeStackingLip(self, obj):
         obj.StackingLipBottomChamfer + obj.StackingLipVerticalSection,
     )
     ST5 = App.Vector(
-        -obj.BinUnit / 2 + obj.StackingLipTopLedge + obj.StackingLipTopChamfer, 0, obj.StackingLipBottomChamfer
+        -obj.BinUnit / 2 + obj.StackingLipTopLedge + obj.StackingLipTopChamfer,
+        0,
+        obj.StackingLipBottomChamfer,
     )
     ST6 = App.Vector(
-        -obj.BinUnit / 2 + obj.StackingLipTopLedge + obj.StackingLipTopChamfer + obj.StackingLipBottomChamfer, 0, 0
+        -obj.BinUnit / 2
+        + obj.StackingLipTopLedge
+        + obj.StackingLipTopChamfer
+        + obj.StackingLipBottomChamfer,
+        0,
+        0,
     )
     ST7 = App.Vector(
-        -obj.BinUnit / 2 + obj.StackingLipTopLedge + obj.StackingLipTopChamfer + obj.StackingLipBottomChamfer,
+        -obj.BinUnit / 2
+        + obj.StackingLipTopLedge
+        + obj.StackingLipTopChamfer
+        + obj.StackingLipBottomChamfer,
         0,
         -obj.StackingLipVerticalSection,
     )
@@ -438,7 +504,12 @@ def MakeStackingLip(self, obj):
         -obj.BinUnit / 2 + obj.WallThickness,
         0,
         -obj.StackingLipVerticalSection
-        - (obj.StackingLipTopLedge + obj.StackingLipTopChamfer + obj.StackingLipBottomChamfer - obj.WallThickness),
+        - (
+            obj.StackingLipTopLedge
+            + obj.StackingLipTopChamfer
+            + obj.StackingLipBottomChamfer
+            - obj.WallThickness
+        ),
     )
     ST9 = App.Vector(-obj.BinUnit / 2 + obj.WallThickness, 0, 0)
 
@@ -463,7 +534,6 @@ def MakeStackingLip(self, obj):
 
 
 def MakeCompartements(self, obj):
-
     xdivheight = obj.xDividerHeight if obj.xDividerHeight != 0 else obj.TotalHeight
     ydivheight = obj.yDividerHeight if obj.yDividerHeight != 0 else obj.TotalHeight
 
@@ -474,7 +544,13 @@ def MakeCompartements(self, obj):
         obj.UsableHeight,
         obj.BinOuterRadius - obj.WallThickness,
     )
-    func_fuse.translate(App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0))
+    func_fuse.translate(
+        App.Vector(
+            obj.xTotalWidth / 2 - obj.BinUnit / 2,
+            obj.yTotalWidth / 2 - obj.BinUnit / 2,
+            0,
+        )
+    )
 
     if obj.xDividers == 0 and obj.yDividers == 0:
         # Fillet Bottom edges
@@ -489,8 +565,16 @@ def MakeCompartements(self, obj):
         func_fuse = func_fuse.makeFillet(obj.InsideFilletRadius, b_edges)
 
     else:
-        xcomp_w = (obj.xTotalWidth - obj.WallThickness * 2 - obj.xDividers * obj.DividerThickness) / (obj.xDividers + 1)
-        ycomp_w = (obj.yTotalWidth - obj.WallThickness * 2 - obj.yDividers * obj.DividerThickness) / (obj.yDividers + 1)
+        xcomp_w = (
+            obj.xTotalWidth
+            - obj.WallThickness * 2
+            - obj.xDividers * obj.DividerThickness
+        ) / (obj.xDividers + 1)
+        ycomp_w = (
+            obj.yTotalWidth
+            - obj.WallThickness * 2
+            - obj.yDividers * obj.DividerThickness
+        ) / (obj.yDividers + 1)
 
         xtranslate = zeromm + xcomp_w + obj.WallThickness - obj.DividerThickness
         ytranslate = zeromm + ycomp_w + obj.WallThickness
@@ -501,7 +585,11 @@ def MakeCompartements(self, obj):
                 obj.DividerThickness,
                 obj.yTotalWidth,
                 xdivheight,
-                App.Vector(-obj.BinUnit / 2 + obj.DividerThickness, -obj.BinUnit / 2, -obj.TotalHeight),
+                App.Vector(
+                    -obj.BinUnit / 2 + obj.DividerThickness,
+                    -obj.BinUnit / 2,
+                    -obj.TotalHeight,
+                ),
                 App.Vector(0, 0, 1),
             )
             comp.translate(App.Vector(xtranslate, 0, 0))
@@ -550,24 +638,40 @@ def MakeCompartements(self, obj):
 
 
 def MakeBinWall(self, obj):
-
-    bin_wall_path = createRoundedRectangle(obj.xTotalWidth, obj.yTotalWidth, 0, obj.BinOuterRadius)
-    bin_wall_path.translate(App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0))
+    bin_wall_path = createRoundedRectangle(
+        obj.xTotalWidth, obj.yTotalWidth, 0, obj.BinOuterRadius
+    )
+    bin_wall_path.translate(
+        App.Vector(
+            obj.xTotalWidth / 2 - obj.BinUnit / 2,
+            obj.yTotalWidth / 2 - obj.BinUnit / 2,
+            0,
+        )
+    )
     ST1 = App.Vector(-obj.BinUnit / 2, 0, -obj.TotalHeight + obj.BaseProfileHeight)
     ST2 = App.Vector(-obj.BinUnit / 2, 0, 0)
     ST3 = App.Vector(-obj.BinUnit / 2 + obj.WallThickness, 0, 0)
     ST4 = App.Vector(
-        -obj.BinUnit / 2 + obj.WallThickness, 0, -obj.TotalHeight + obj.HeightUnitValue + obj.InsideFilletRadius
+        -obj.BinUnit / 2 + obj.WallThickness,
+        0,
+        -obj.TotalHeight + obj.HeightUnitValue + obj.InsideFilletRadius,
     )
     ST5 = App.Vector(
-        -obj.BinUnit / 2 + obj.WallThickness + obj.InsideFilletRadius, 0, -obj.TotalHeight + obj.HeightUnitValue
+        -obj.BinUnit / 2 + obj.WallThickness + obj.InsideFilletRadius,
+        0,
+        -obj.TotalHeight + obj.HeightUnitValue,
     )
     ST6 = App.Vector(
-        -obj.BinUnit / 2 + obj.WallThickness + obj.InsideFilletRadius, 0, -obj.TotalHeight + obj.BaseProfileHeight
+        -obj.BinUnit / 2 + obj.WallThickness + obj.InsideFilletRadius,
+        0,
+        -obj.TotalHeight + obj.BaseProfileHeight,
     )
 
     VC1 = App.Vector(
-        -obj.BinUnit / 2 + obj.WallThickness + obj.InsideFilletRadius - obj.InsideFilletRadius * math.sin(math.pi / 4),
+        -obj.BinUnit / 2
+        + obj.WallThickness
+        + obj.InsideFilletRadius
+        - obj.InsideFilletRadius * math.sin(math.pi / 4),
         0,
         -obj.TotalHeight
         + obj.HeightUnitValue
@@ -595,7 +699,9 @@ def MakeBinWall(self, obj):
 def MakeBinBase(self, obj):
     components = []
     basecomp = []
-    bt_cmf_width = obj.BinUnit - 2 * obj.BaseProfileBottomChamfer - 2 * obj.BaseProfileTopChamfer
+    bt_cmf_width = (
+        obj.BinUnit - 2 * obj.BaseProfileBottomChamfer - 2 * obj.BaseProfileTopChamfer
+    )
     vert_width = obj.BinUnit - 2 * obj.BaseProfileTopChamfer
     xtranslate = zeromm
     ytranslate = zeromm
@@ -603,7 +709,11 @@ def MakeBinBase(self, obj):
         ytranslate = zeromm
         for y in range(obj.yGridUnits):
             bottom_chamfer = RoundedRectangleChamfer(
-                bt_cmf_width, bt_cmf_width, -obj.TotalHeight, obj.BaseProfileBottomChamfer, obj.BinBottomRadius
+                bt_cmf_width,
+                bt_cmf_width,
+                -obj.TotalHeight,
+                obj.BaseProfileBottomChamfer,
+                obj.BinBottomRadius,
             )
 
             vertical_section = RoundedRectangleExtrude(
@@ -618,7 +728,9 @@ def MakeBinBase(self, obj):
             top_chamfer = RoundedRectangleChamfer(
                 vert_width,
                 vert_width,
-                -obj.TotalHeight + obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection,
+                -obj.TotalHeight
+                + obj.BaseProfileBottomChamfer
+                + obj.BaseProfileVerticalSection,
                 obj.BaseProfileTopChamfer,
                 obj.BinVerticalRadius,
             )
@@ -640,11 +752,18 @@ def MakeBinBase(self, obj):
 
 
 def MakeBaseplateCenterCut(self, obj):
-
     inframedis = (
-        obj.GridSize / 2 - obj.BaseProfileTopChamfer - obj.BaseProfileBottomChamfer - obj.BaseplateTopLedgeWidth
+        obj.GridSize / 2
+        - obj.BaseProfileTopChamfer
+        - obj.BaseProfileBottomChamfer
+        - obj.BaseplateTopLedgeWidth
     )
-    magedge = obj.GridSize / 2 - obj.MagnetHoleDistanceFromEdge - obj.MagnetHoleDiameter / 2 - obj.MagnetEdgeThickness
+    magedge = (
+        obj.GridSize / 2
+        - obj.MagnetHoleDistanceFromEdge
+        - obj.MagnetHoleDiameter / 2
+        - obj.MagnetEdgeThickness
+    )
     magcenter = obj.GridSize / 2 - obj.MagnetHoleDistanceFromEdge
     smfillpos = inframedis - obj.SmallFillet + obj.SmallFillet * math.sin(math.pi / 4)
     smfillposmag = magedge - obj.SmallFillet + obj.SmallFillet * math.sin(math.pi / 4)
@@ -769,7 +888,6 @@ def MakeBaseplateCenterCut(self, obj):
     for x in range(obj.xGridUnits):
         ytranslate = zeromm
         for y in range(obj.yGridUnits):
-
             HM1 = face.extrude(App.Vector(0, 0, -obj.TotalHeight))
 
             HM1.translate(App.Vector(xtranslate, ytranslate, 0))
@@ -789,7 +907,9 @@ def MakeBaseplateCenterCut(self, obj):
 
 def MakeBottomHoles(self, obj):
     hole_pos = obj.GridSize / 2 - obj.MagnetHoleDistanceFromEdge
-    sq_bridge2_pos = -obj.GridSize / 2 + obj.MagnetHoleDistanceFromEdge + obj.ScrewHoleDiameter / 2
+    sq_bridge2_pos = (
+        -obj.GridSize / 2 + obj.MagnetHoleDistanceFromEdge + obj.ScrewHoleDiameter / 2
+    )
 
     sqbr1_depth = obj.MagnetHoleDepth + obj.SequentialBridgingLayerHeight
     sqbr2_depth = obj.MagnetHoleDepth + obj.SequentialBridgingLayerHeight * 2
@@ -812,7 +932,9 @@ def MakeBottomHoles(self, obj):
                     p = App.ActiveDocument.addObject("Part::RegularPolygon")
                     p.Polygon = nSides
                     p.Circumradius = obj.MagnetHoleDiameter / 2
-                    p.Placement = App.Placement(App.Vector(-hole_pos, -hole_pos, -obj.TotalHeight), rot)
+                    p.Placement = App.Placement(
+                        App.Vector(-hole_pos, -hole_pos, -obj.TotalHeight), rot
+                    )
                     p.recompute()
                     f = Part.Face(Part.Wire(p.Shape.Edges))
                     C1 = f.extrude(App.Vector(0, 0, obj.MagnetHoleDepth))
@@ -821,7 +943,9 @@ def MakeBottomHoles(self, obj):
                     p = App.ActiveDocument.addObject("Part::RegularPolygon")
                     p.Polygon = nSides
                     p.Circumradius = obj.MagnetHoleDiameter / 2
-                    p.Placement = App.Placement(App.Vector(hole_pos, -hole_pos, -obj.TotalHeight), rot)
+                    p.Placement = App.Placement(
+                        App.Vector(hole_pos, -hole_pos, -obj.TotalHeight), rot
+                    )
                     p.recompute()
                     f = Part.Face(Part.Wire(p.Shape.Edges))
                     C2 = f.extrude(App.Vector(0, 0, obj.MagnetHoleDepth))
@@ -830,7 +954,9 @@ def MakeBottomHoles(self, obj):
                     p = App.ActiveDocument.addObject("Part::RegularPolygon")
                     p.Polygon = nSides
                     p.Circumradius = obj.MagnetHoleDiameter / 2
-                    p.Placement = App.Placement(App.Vector(-hole_pos, hole_pos, -obj.TotalHeight), rot)
+                    p.Placement = App.Placement(
+                        App.Vector(-hole_pos, hole_pos, -obj.TotalHeight), rot
+                    )
                     p.recompute()
                     f = Part.Face(Part.Wire(p.Shape.Edges))
                     C3 = f.extrude(App.Vector(0, 0, obj.MagnetHoleDepth))
@@ -839,7 +965,9 @@ def MakeBottomHoles(self, obj):
                     p = App.ActiveDocument.addObject("Part::RegularPolygon")
                     p.Polygon = nSides
                     p.Circumradius = obj.MagnetHoleDiameter / 2
-                    p.Placement = App.Placement(App.Vector(hole_pos, hole_pos, -obj.TotalHeight), rot)
+                    p.Placement = App.Placement(
+                        App.Vector(hole_pos, hole_pos, -obj.TotalHeight), rot
+                    )
                     p.recompute()
                     f = Part.Face(Part.Wire(p.Shape.Edges))
                     C4 = f.extrude(App.Vector(0, 0, obj.MagnetHoleDepth))
@@ -949,7 +1077,9 @@ def MakeBottomHoles(self, obj):
                     obj.ScrewHoleDiameter,
                     sqbr2_depth,
                     App.Vector(
-                        -obj.GridSize / 2 + obj.MagnetHoleDistanceFromEdge - obj.ScrewHoleDiameter / 2,
+                        -obj.GridSize / 2
+                        + obj.MagnetHoleDistanceFromEdge
+                        - obj.ScrewHoleDiameter / 2,
                         -sq_bridge2_pos,
                         -obj.TotalHeight,
                     ),
@@ -961,7 +1091,9 @@ def MakeBottomHoles(self, obj):
                     sqbr2_depth,
                     App.Vector(
                         -sq_bridge2_pos,
-                        -obj.GridSize / 2 + obj.MagnetHoleDistanceFromEdge - obj.ScrewHoleDiameter / 2,
+                        -obj.GridSize / 2
+                        + obj.MagnetHoleDistanceFromEdge
+                        - obj.ScrewHoleDiameter / 2,
                         -obj.TotalHeight,
                     ),
                     App.Vector(0, 0, 1),
@@ -971,45 +1103,100 @@ def MakeBottomHoles(self, obj):
                     obj.ScrewHoleDiameter,
                     sqbr2_depth,
                     App.Vector(
-                        -obj.GridSize / 2 + obj.MagnetHoleDistanceFromEdge - obj.ScrewHoleDiameter / 2,
-                        -obj.GridSize / 2 + obj.MagnetHoleDistanceFromEdge - obj.ScrewHoleDiameter / 2,
+                        -obj.GridSize / 2
+                        + obj.MagnetHoleDistanceFromEdge
+                        - obj.ScrewHoleDiameter / 2,
+                        -obj.GridSize / 2
+                        + obj.MagnetHoleDistanceFromEdge
+                        - obj.ScrewHoleDiameter / 2,
                         -obj.TotalHeight,
                     ),
                     App.Vector(0, 0, 1),
                 )
 
                 arc_pt_off_x = (
-                    math.sqrt(((obj.MagnetHoleDiameter / 2) ** 2) - ((obj.ScrewHoleDiameter / 2) ** 2))
+                    math.sqrt(
+                        ((obj.MagnetHoleDiameter / 2) ** 2)
+                        - ((obj.ScrewHoleDiameter / 2) ** 2)
+                    )
                 ) * unitmm
                 arc_pt_off_y = obj.ScrewHoleDiameter / 2
 
-                VA1 = App.Vector(hole_pos + arc_pt_off_x, hole_pos + arc_pt_off_y, -obj.TotalHeight)
-                VA2 = App.Vector(hole_pos - arc_pt_off_x, hole_pos + arc_pt_off_y, -obj.TotalHeight)
-                VA3 = App.Vector(hole_pos - arc_pt_off_x, hole_pos - arc_pt_off_y, -obj.TotalHeight)
-                VA4 = App.Vector(hole_pos + arc_pt_off_x, hole_pos - arc_pt_off_y, -obj.TotalHeight)
-                VAR1 = App.Vector(hole_pos + obj.MagnetHoleDiameter / 2, hole_pos, -obj.TotalHeight)
-                VAR2 = App.Vector(hole_pos - obj.MagnetHoleDiameter / 2, hole_pos, -obj.TotalHeight)
+                VA1 = App.Vector(
+                    hole_pos + arc_pt_off_x, hole_pos + arc_pt_off_y, -obj.TotalHeight
+                )
+                VA2 = App.Vector(
+                    hole_pos - arc_pt_off_x, hole_pos + arc_pt_off_y, -obj.TotalHeight
+                )
+                VA3 = App.Vector(
+                    hole_pos - arc_pt_off_x, hole_pos - arc_pt_off_y, -obj.TotalHeight
+                )
+                VA4 = App.Vector(
+                    hole_pos + arc_pt_off_x, hole_pos - arc_pt_off_y, -obj.TotalHeight
+                )
+                VAR1 = App.Vector(
+                    hole_pos + obj.MagnetHoleDiameter / 2, hole_pos, -obj.TotalHeight
+                )
+                VAR2 = App.Vector(
+                    hole_pos - obj.MagnetHoleDiameter / 2, hole_pos, -obj.TotalHeight
+                )
 
-                VA5 = App.Vector(-hole_pos + arc_pt_off_x, hole_pos + arc_pt_off_y, -obj.TotalHeight)
-                VA6 = App.Vector(-hole_pos - arc_pt_off_x, hole_pos + arc_pt_off_y, -obj.TotalHeight)
-                VA7 = App.Vector(-hole_pos - arc_pt_off_x, hole_pos - arc_pt_off_y, -obj.TotalHeight)
-                VA8 = App.Vector(-hole_pos + arc_pt_off_x, hole_pos - arc_pt_off_y, -obj.TotalHeight)
-                VAR3 = App.Vector(-hole_pos + obj.MagnetHoleDiameter / 2, hole_pos, -obj.TotalHeight)
-                VAR4 = App.Vector(-hole_pos - obj.MagnetHoleDiameter / 2, hole_pos, -obj.TotalHeight)
+                VA5 = App.Vector(
+                    -hole_pos + arc_pt_off_x, hole_pos + arc_pt_off_y, -obj.TotalHeight
+                )
+                VA6 = App.Vector(
+                    -hole_pos - arc_pt_off_x, hole_pos + arc_pt_off_y, -obj.TotalHeight
+                )
+                VA7 = App.Vector(
+                    -hole_pos - arc_pt_off_x, hole_pos - arc_pt_off_y, -obj.TotalHeight
+                )
+                VA8 = App.Vector(
+                    -hole_pos + arc_pt_off_x, hole_pos - arc_pt_off_y, -obj.TotalHeight
+                )
+                VAR3 = App.Vector(
+                    -hole_pos + obj.MagnetHoleDiameter / 2, hole_pos, -obj.TotalHeight
+                )
+                VAR4 = App.Vector(
+                    -hole_pos - obj.MagnetHoleDiameter / 2, hole_pos, -obj.TotalHeight
+                )
 
-                VA9 = App.Vector(hole_pos + arc_pt_off_x, -hole_pos + arc_pt_off_y, -obj.TotalHeight)
-                VA10 = App.Vector(hole_pos - arc_pt_off_x, -hole_pos + arc_pt_off_y, -obj.TotalHeight)
-                VA11 = App.Vector(hole_pos - arc_pt_off_x, -hole_pos - arc_pt_off_y, -obj.TotalHeight)
-                VA12 = App.Vector(hole_pos + arc_pt_off_x, -hole_pos - arc_pt_off_y, -obj.TotalHeight)
-                VAR5 = App.Vector(hole_pos + obj.MagnetHoleDiameter / 2, -hole_pos, -obj.TotalHeight)
-                VAR6 = App.Vector(hole_pos - obj.MagnetHoleDiameter / 2, -hole_pos, -obj.TotalHeight)
+                VA9 = App.Vector(
+                    hole_pos + arc_pt_off_x, -hole_pos + arc_pt_off_y, -obj.TotalHeight
+                )
+                VA10 = App.Vector(
+                    hole_pos - arc_pt_off_x, -hole_pos + arc_pt_off_y, -obj.TotalHeight
+                )
+                VA11 = App.Vector(
+                    hole_pos - arc_pt_off_x, -hole_pos - arc_pt_off_y, -obj.TotalHeight
+                )
+                VA12 = App.Vector(
+                    hole_pos + arc_pt_off_x, -hole_pos - arc_pt_off_y, -obj.TotalHeight
+                )
+                VAR5 = App.Vector(
+                    hole_pos + obj.MagnetHoleDiameter / 2, -hole_pos, -obj.TotalHeight
+                )
+                VAR6 = App.Vector(
+                    hole_pos - obj.MagnetHoleDiameter / 2, -hole_pos, -obj.TotalHeight
+                )
 
-                VA13 = App.Vector(-hole_pos + arc_pt_off_x, -hole_pos + arc_pt_off_y, -obj.TotalHeight)
-                VA14 = App.Vector(-hole_pos - arc_pt_off_x, -hole_pos + arc_pt_off_y, -obj.TotalHeight)
-                VA15 = App.Vector(-hole_pos - arc_pt_off_x, -hole_pos - arc_pt_off_y, -obj.TotalHeight)
-                VA16 = App.Vector(-hole_pos + arc_pt_off_x, -hole_pos - arc_pt_off_y, -obj.TotalHeight)
-                VAR7 = App.Vector(-hole_pos + obj.MagnetHoleDiameter / 2, -hole_pos, -obj.TotalHeight)
-                VAR8 = App.Vector(-hole_pos - obj.MagnetHoleDiameter / 2, -hole_pos, -obj.TotalHeight)
+                VA13 = App.Vector(
+                    -hole_pos + arc_pt_off_x, -hole_pos + arc_pt_off_y, -obj.TotalHeight
+                )
+                VA14 = App.Vector(
+                    -hole_pos - arc_pt_off_x, -hole_pos + arc_pt_off_y, -obj.TotalHeight
+                )
+                VA15 = App.Vector(
+                    -hole_pos - arc_pt_off_x, -hole_pos - arc_pt_off_y, -obj.TotalHeight
+                )
+                VA16 = App.Vector(
+                    -hole_pos + arc_pt_off_x, -hole_pos - arc_pt_off_y, -obj.TotalHeight
+                )
+                VAR7 = App.Vector(
+                    -hole_pos + obj.MagnetHoleDiameter / 2, -hole_pos, -obj.TotalHeight
+                )
+                VAR8 = App.Vector(
+                    -hole_pos - obj.MagnetHoleDiameter / 2, -hole_pos, -obj.TotalHeight
+                )
 
                 L1 = Part.LineSegment(VA1, VA2)
                 L2 = Part.LineSegment(VA3, VA4)
@@ -1076,7 +1263,6 @@ def MakeBottomHoles(self, obj):
 
 
 def MakeEcoBinCut(self, obj):
-
     func_fuse = RoundedRectangleExtrude(
         obj.xTotalWidth - obj.WallThickness * 2,
         obj.yTotalWidth - obj.WallThickness * 2,
@@ -1084,10 +1270,21 @@ def MakeEcoBinCut(self, obj):
         obj.TotalHeight - obj.BaseProfileHeight - obj.BaseWallThickness,
         obj.BinOuterRadius - obj.WallThickness,
     )
-    func_fuse.translate(App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0))
+    func_fuse.translate(
+        App.Vector(
+            obj.xTotalWidth / 2 - obj.BinUnit / 2,
+            obj.yTotalWidth / 2 - obj.BinUnit / 2,
+            0,
+        )
+    )
 
     base_offset = obj.BaseWallThickness * math.tan(math.pi / 8)
-    bt_cmf_width = obj.BinUnit - 2 * obj.BaseProfileTopChamfer - obj.BaseWallThickness * 2 - 0.4 * unitmm * 2
+    bt_cmf_width = (
+        obj.BinUnit
+        - 2 * obj.BaseProfileTopChamfer
+        - obj.BaseWallThickness * 2
+        - 0.4 * unitmm * 2
+    )
     vert_width = obj.BinUnit - 2 * obj.BaseProfileTopChamfer - obj.BaseWallThickness * 2
     bt_chf_rad = obj.BinVerticalRadius - 0.4 * unitmm - obj.BaseWallThickness
     v_chf_rad = obj.BinVerticalRadius - obj.BaseWallThickness
@@ -1098,7 +1295,9 @@ def MakeEcoBinCut(self, obj):
             obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + base_offset
         ):
             tp_chf_offset = (obj.MagnetHoleDepth + obj.BaseWallThickness) - (
-                obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + base_offset
+                obj.BaseProfileBottomChamfer
+                + obj.BaseProfileVerticalSection
+                + base_offset
             )
         else:
             tp_chf_offset = 0 * unitmm
@@ -1118,7 +1317,6 @@ def MakeEcoBinCut(self, obj):
     for x in range(obj.xGridUnits):
         ytranslate = zeromm
         for y in range(obj.yGridUnits):
-
             bottom_chamfer = RoundedRectangleChamfer(
                 bt_cmf_width,
                 bt_cmf_width,
@@ -1174,7 +1372,13 @@ def MakeEcoBinCut(self, obj):
         obj.TotalHeight,
         obj.BinOuterRadius - obj.WallThickness,
     )
-    outer_trim1.translate(App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0))
+    outer_trim1.translate(
+        App.Vector(
+            obj.xTotalWidth / 2 - obj.BinUnit / 2,
+            obj.yTotalWidth / 2 - obj.BinUnit / 2,
+            0,
+        )
+    )
 
     outer_trim2 = RoundedRectangleExtrude(
         obj.xTotalWidth + 20 * unitmm,
@@ -1183,15 +1387,25 @@ def MakeEcoBinCut(self, obj):
         obj.TotalHeight - obj.BaseProfileHeight,
         obj.BinOuterRadius,
     )
-    outer_trim2.translate(App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0))
+    outer_trim2.translate(
+        App.Vector(
+            obj.xTotalWidth / 2 - obj.BinUnit / 2,
+            obj.yTotalWidth / 2 - obj.BinUnit / 2,
+            0,
+        )
+    )
 
     outer_trim2 = outer_trim2.cut(outer_trim1)
 
     func_fuse = func_fuse.cut(outer_trim2)
     # Dividers
 
-    xcomp_w = (obj.xTotalWidth - obj.WallThickness * 2 - obj.xDividers * obj.DividerThickness) / (obj.xDividers + 1)
-    ycomp_w = (obj.yTotalWidth - obj.WallThickness * 2 - obj.yDividers * obj.DividerThickness) / (obj.yDividers + 1)
+    xcomp_w = (
+        obj.xTotalWidth - obj.WallThickness * 2 - obj.xDividers * obj.DividerThickness
+    ) / (obj.xDividers + 1)
+    ycomp_w = (
+        obj.yTotalWidth - obj.WallThickness * 2 - obj.yDividers * obj.DividerThickness
+    ) / (obj.yDividers + 1)
 
     xdivheight = obj.xDividerHeight if obj.xDividerHeight != 0 else obj.TotalHeight
     ydivheight = obj.yDividerHeight if obj.yDividerHeight != 0 else obj.TotalHeight
@@ -1205,7 +1419,11 @@ def MakeEcoBinCut(self, obj):
             obj.DividerThickness,
             obj.yTotalWidth,
             xdivheight,
-            App.Vector(-obj.BinUnit / 2 + obj.DividerThickness, -obj.BinUnit / 2, -obj.TotalHeight),
+            App.Vector(
+                -obj.BinUnit / 2 + obj.DividerThickness,
+                -obj.BinUnit / 2,
+                -obj.TotalHeight,
+            ),
             App.Vector(0, 0, 1),
         )
         comp.translate(App.Vector(xtranslate, 0, 0))
@@ -1238,7 +1456,9 @@ def MakeEcoBinCut(self, obj):
         func_fuse = func_fuse.cut(ydiv)
     b_edges = []
 
-    divfil = -obj.TotalHeight + obj.BaseProfileHeight + obj.BaseWallThickness + 1 * unitmm
+    divfil = (
+        -obj.TotalHeight + obj.BaseProfileHeight + obj.BaseWallThickness + 1 * unitmm
+    )
     for idx_edge, edge in enumerate(func_fuse.Edges):
         z0 = edge.Vertexes[0].Point.z
         z1 = edge.Vertexes[1].Point.z

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -800,30 +800,72 @@ def MakeBottomHoles(self, obj):
         for x in range(obj.xGridUnits):
             ytranslate = zeromm
             for y in range(obj.yGridUnits):
-                C1 = Part.makeCylinder(
-                    obj.MagnetHoleDiameter / 2,
-                    obj.MagnetHoleDepth,
-                    App.Vector(-hole_pos, -hole_pos, -obj.TotalHeight),
-                    App.Vector(0, 0, 1),
-                )
-                C2 = Part.makeCylinder(
-                    obj.MagnetHoleDiameter / 2,
-                    obj.MagnetHoleDepth,
-                    App.Vector(hole_pos, -hole_pos, -obj.TotalHeight),
-                    App.Vector(0, 0, 1),
-                )
-                C3 = Part.makeCylinder(
-                    obj.MagnetHoleDiameter / 2,
-                    obj.MagnetHoleDepth,
-                    App.Vector(-hole_pos, hole_pos, -obj.TotalHeight),
-                    App.Vector(0, 0, 1),
-                )
-                C4 = Part.makeCylinder(
-                    obj.MagnetHoleDiameter / 2,
-                    obj.MagnetHoleDepth,
-                    App.Vector(hole_pos, hole_pos, -obj.TotalHeight),
-                    App.Vector(0, 0, 1),
-                )
+                if obj.MagnetHolesShape == "Hex":
+                    nSides = 6
+
+                    rot = App.Rotation(App.Vector(0, 0, 1), 0)
+
+                    p = App.ActiveDocument.addObject("Part::RegularPolygon")
+                    p.Polygon = nSides
+                    p.Circumradius = obj.MagnetHoleDiameter / 2
+                    p.Placement = App.Placement(App.Vector(-hole_pos, -hole_pos, -obj.TotalHeight), rot)
+                    p.recompute()
+                    f = Part.Face(Part.Wire(p.Shape.Edges))
+                    C1 = f.extrude(App.Vector(0, 0, obj.MagnetHoleDepth))
+                    App.ActiveDocument.removeObject(p.Name)
+
+                    p = App.ActiveDocument.addObject("Part::RegularPolygon")
+                    p.Polygon = nSides
+                    p.Circumradius = obj.MagnetHoleDiameter / 2
+                    p.Placement = App.Placement(App.Vector(hole_pos, -hole_pos, -obj.TotalHeight), rot)
+                    p.recompute()
+                    f = Part.Face(Part.Wire(p.Shape.Edges))
+                    C2 = f.extrude(App.Vector(0, 0, obj.MagnetHoleDepth))
+                    App.ActiveDocument.removeObject(p.Name)
+
+                    p = App.ActiveDocument.addObject("Part::RegularPolygon")
+                    p.Polygon = nSides
+                    p.Circumradius = obj.MagnetHoleDiameter / 2
+                    p.Placement = App.Placement(App.Vector(-hole_pos, hole_pos, -obj.TotalHeight), rot)
+                    p.recompute()
+                    f = Part.Face(Part.Wire(p.Shape.Edges))
+                    C3 = f.extrude(App.Vector(0, 0, obj.MagnetHoleDepth))
+                    App.ActiveDocument.removeObject(p.Name)
+
+                    p = App.ActiveDocument.addObject("Part::RegularPolygon")
+                    p.Polygon = nSides
+                    p.Circumradius = obj.MagnetHoleDiameter / 2
+                    p.Placement = App.Placement(App.Vector(hole_pos, hole_pos, -obj.TotalHeight), rot)
+                    p.recompute()
+                    f = Part.Face(Part.Wire(p.Shape.Edges))
+                    C4 = f.extrude(App.Vector(0, 0, obj.MagnetHoleDepth))
+                    App.ActiveDocument.removeObject(p.Name)
+
+                else:
+                    C1 = Part.makeCylinder(
+                        obj.MagnetHoleDiameter / 2,
+                        obj.MagnetHoleDepth,
+                        App.Vector(-hole_pos, -hole_pos, -obj.TotalHeight),
+                        App.Vector(0, 0, 1),
+                    )
+                    C2 = Part.makeCylinder(
+                        obj.MagnetHoleDiameter / 2,
+                        obj.MagnetHoleDepth,
+                        App.Vector(hole_pos, -hole_pos, -obj.TotalHeight),
+                        App.Vector(0, 0, 1),
+                    )
+                    C3 = Part.makeCylinder(
+                        obj.MagnetHoleDiameter / 2,
+                        obj.MagnetHoleDepth,
+                        App.Vector(-hole_pos, hole_pos, -obj.TotalHeight),
+                        App.Vector(0, 0, 1),
+                    )
+                    C4 = Part.makeCylinder(
+                        obj.MagnetHoleDiameter / 2,
+                        obj.MagnetHoleDepth,
+                        App.Vector(hole_pos, hole_pos, -obj.TotalHeight),
+                        App.Vector(0, 0, 1),
+                    )
 
                 HM1 = Part.Solid.multiFuse(C1, [C2, C3, C4])
 

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -914,10 +914,6 @@ def MakeBottomHoles(self, obj):
     sqbr1_depth = obj.MagnetHoleDepth + obj.SequentialBridgingLayerHeight
     sqbr2_depth = obj.MagnetHoleDepth + obj.SequentialBridgingLayerHeight * 2
 
-    # This could be sped up if by creating copies of Solids and moving those.
-    # Create 1 hole, copy it 3x and move it to the correct position.
-    # Then create copies of the fused 4 holes and move them to the correct position per row & col.
-
     xtranslate = zeromm
     ytranslate = zeromm
     if obj.MagnetHoles:

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -1,5 +1,7 @@
 from __future__ import division
 import os
+import numpy as np
+import math
 import FreeCAD as App
 import Part
 from FreeCAD import Units
@@ -156,7 +158,7 @@ class BinBlank(FoundationGridfinity):
         ).xGridUnits = 2
         obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
         obj.addProperty(
-            "App::PropertyInteger", "HeightUnits", "Gridfinity", "height of the bin in units, each is 7 mm"
+            "App::PropertyInteger", "HeightUnits", "Gridfinity", "Height of the bin in units, each is 7 mm"
         ).HeightUnits = 6
         obj.addProperty(
             "App::PropertyBool", "StackingLip", "Gridfinity", "Toggle the stacking lip on or off"
@@ -166,14 +168,14 @@ class BinBlank(FoundationGridfinity):
         ).MagnetHoles = True
         obj.addProperty(
             "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
-        ).ScrewHoles = True
+        ).ScrewHoles = False
 
     def add_custom_bin_properties(self, obj):
         obj.addProperty(
             "App::PropertyLength",
             "CustomHeight",
             "GridfinityNonStandard",
-            "total height of the bin using the custom heignt instead of incraments of 7 mm",
+            "total height of the bin using the custom height instead of increments of 7 mm",
         ).CustomHeight = 42
         obj.addProperty(
             "App::PropertyLength",
@@ -184,6 +186,13 @@ class BinBlank(FoundationGridfinity):
         obj.addProperty(
             "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
         ).NonStandardHeight = False
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "MagnetHolesShape",
+            "GridfinityNonStandard",
+            "Shape of magnet holes. <br> <br> Hex meant to be press fit. <br> Round meant to be glued",
+        )
+        obj.MagnetHolesShape = ["Hex", "Round"]
         obj.addProperty(
             "App::PropertyLength",
             "MagnetHoleDiameter",
@@ -386,14 +395,14 @@ class BinBase(FoundationGridfinity):
         ).MagnetHoles = True
         obj.addProperty(
             "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
-        ).ScrewHoles = True
+        ).ScrewHoles = False
 
     def add_custom_bin_properties(self, obj):
         obj.addProperty(
             "App::PropertyLength",
             "CustomHeight",
             "GridfinityNonStandard",
-            "total height of the bin using the custom heignt instead of incraments of 7 mm",
+            "total height of the bin using the custom heignt instead of increments of 7 mm",
         ).CustomHeight = 42
         obj.addProperty(
             "App::PropertyLength",
@@ -404,6 +413,13 @@ class BinBase(FoundationGridfinity):
         obj.addProperty(
             "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
         ).NonStandardHeight = False
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "MagnetHolesShape",
+            "GridfinityNonStandard",
+            "Shape of magnet holes. <br> <br> Hex meant to be press fit. <br> Round meant to be glued",
+        )
+        obj.MagnetHolesShape = ["Hex", "Round"]
         obj.addProperty(
             "App::PropertyLength",
             "MagnetHoleDiameter",
@@ -597,7 +613,7 @@ class SimpleStorageBin(FoundationGridfinity):
         ).xGridUnits = 2
         obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
         obj.addProperty(
-            "App::PropertyInteger", "HeightUnits", "Gridfinity", "height of the bin in units, each unit is 7 mm"
+            "App::PropertyInteger", "HeightUnits", "Gridfinity", "Height of the bin in units, each unit is 7 mm"
         ).HeightUnits = 6
         obj.addProperty(
             "App::PropertyBool", "StackingLip", "Gridfinity", "Toggle the stacking lip on or off"
@@ -607,7 +623,7 @@ class SimpleStorageBin(FoundationGridfinity):
         ).MagnetHoles = True
         obj.addProperty(
             "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
-        ).ScrewHoles = True
+        ).ScrewHoles = False
         obj.addProperty("App::PropertyBool", "Scoop", "Gridfinity", "Toggle the Scoop fillet on or off").Scoop = False
         obj.addProperty(
             "App::PropertyInteger", "xDividers", "Gridfinity", "Select the Number of Dividers in the x direction"
@@ -629,7 +645,7 @@ class SimpleStorageBin(FoundationGridfinity):
             "App::PropertyLength",
             "CustomHeight",
             "GridfinityNonStandard",
-            "total height of the bin using the custom heignt instead of incraments of 7 mm",
+            "total height of the bin using the custom height instead of increments of 7 mm",
         ).CustomHeight = 42
         obj.addProperty(
             "App::PropertyLength",
@@ -640,6 +656,13 @@ class SimpleStorageBin(FoundationGridfinity):
         obj.addProperty(
             "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
         ).NonStandardHeight = False
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "MagnetHolesShape",
+            "GridfinityNonStandard",
+            "Shape of magnet holes. <br> <br> Hex meant to be press fit. <br> Round meant to be glued",
+        )
+        obj.MagnetHolesShape = ["Hex", "Round"]
         obj.addProperty(
             "App::PropertyLength",
             "MagnetHoleDiameter",
@@ -946,7 +969,7 @@ class EcoBin(FoundationGridfinity):
             "App::PropertyLength",
             "CustomHeight",
             "GridfinityNonStandard",
-            "total height of the bin using the custom heignt instead of incraments of 7 mm",
+            "total height of the bin using the custom heignt instead of increments of 7 mm",
         ).CustomHeight = 42
         obj.addProperty(
             "App::PropertyLength",
@@ -957,6 +980,13 @@ class EcoBin(FoundationGridfinity):
         obj.addProperty(
             "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
         ).NonStandardHeight = False
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "MagnetHolesShape",
+            "GridfinityNonStandard",
+            "Shape of magnet holes. <br> <br> Hex meant to be press fit. <br> Round meant to be glued",
+        )
+        obj.MagnetHolesShape = ["Hex", "Round"]
         obj.addProperty(
             "App::PropertyLength",
             "MagnetHoleDiameter",
@@ -1220,7 +1250,7 @@ class PartsBin(FoundationGridfinity):
         ).MagnetHoles = True
         obj.addProperty(
             "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
-        ).ScrewHoles = True
+        ).ScrewHoles = False
         obj.addProperty("App::PropertyBool", "Scoop", "Gridfinity", "Toggle the Scoop fillet on or off").Scoop = True
         obj.addProperty(
             "App::PropertyInteger", "xDividers", "Gridfinity", "Select the Number of Dividers in the x direction"
@@ -1242,7 +1272,7 @@ class PartsBin(FoundationGridfinity):
             "App::PropertyLength",
             "CustomHeight",
             "GridfinityNonStandard",
-            "total height of the bin using the custom heignt instead of incraments of 7 mm",
+            "total height of the bin using the custom heignt instead of increments of 7 mm",
         ).CustomHeight = 42
         obj.addProperty(
             "App::PropertyLength",
@@ -1253,6 +1283,13 @@ class PartsBin(FoundationGridfinity):
         obj.addProperty(
             "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
         ).NonStandardHeight = False
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "MagnetHolesShape",
+            "GridfinityNonStandard",
+            "Shape of magnet holes. <br> <br> Hex meant to be press fit. <br> Round meant to be glued",
+        )
+        obj.MagnetHolesShape = ["Hex", "Round"]
         obj.addProperty(
             "App::PropertyLength",
             "MagnetHoleDiameter",

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -17,7 +17,11 @@ from .feature_construction import (
     MakeScoop,
     MakeLabelShelf,
 )
-from .baseplate_feature_construction import MakeBaseplateMagnetHoles, MakeBPScrewBottomCham, MakeBPConnectionHoles
+from .baseplate_feature_construction import (
+    MakeBaseplateMagnetHoles,
+    MakeBPScrewBottomCham,
+    MakeBPConnectionHoles,
+)
 from .const import (
     BIN_BASE_TOP_CHAMFER,
     BIN_BASE_BOTTOM_CHAMFER,
@@ -86,13 +90,21 @@ class ViewProviderGridfinity(object):
         obj.Proxy = self
         self._check_attr()
         dirname = os.path.dirname(__file__)
-        self.icon_fn = icon_fn or os.path.join(dirname, "icons", "gridfinity_workbench_icon.svg")
+        self.icon_fn = icon_fn or os.path.join(
+            dirname, "icons", "gridfinity_workbench_icon.svg"
+        )
         App.Console.PrintMessage("works until here\n")
 
     def _check_attr(self):
         """Check for missing attributes."""
         if not hasattr(self, "icon_fn"):
-            setattr(self, "icon_fn", os.path.join(os.path.dirname(__file__), "icons", "gridfinity_workbench_icon.svg"))
+            setattr(
+                self,
+                "icon_fn",
+                os.path.join(
+                    os.path.dirname(__file__), "icons", "gridfinity_workbench_icon.svg"
+                ),
+            )
 
     def attach(self, vobj):
         self.vobj = vobj
@@ -112,7 +124,13 @@ class ViewProviderGridfinity(object):
 
 class FoundationGridfinity(object):
     def __init__(self, obj):
-        obj.addProperty("App::PropertyString", "version", "version", "Gridfinity Workbench Version", 1)
+        obj.addProperty(
+            "App::PropertyString",
+            "version",
+            "version",
+            "Gridfinity Workbench Version",
+            1,
+        )
         obj.version = __version__
         self.make_attachable(obj)
 
@@ -124,7 +142,9 @@ class FoundationGridfinity(object):
         gridfinity_shape = self.generate_gridfinity_shape(fp)
         if hasattr(fp, "BaseFeature") and fp.BaseFeature is not None:
             # we're inside a PartDesign Body, thus need to fuse with the base feature
-            gridfinity_shape.Placement = fp.Placement  # ensure the bin is placed correctly before fusing
+            gridfinity_shape.Placement = (
+                fp.Placement
+            )  # ensure the bin is placed correctly before fusing
             result_shape = fp.BaseFeature.Shape.fuse(gridfinity_shape)
             result_shape.transformShape(fp.Placement.inverse().toMatrix(), True)
             fp.Shape = result_shape
@@ -139,11 +159,12 @@ class FoundationGridfinity(object):
 
 
 class BinBlank(FoundationGridfinity):
-
     def __init__(self, obj):
         super(BinBlank, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
+        obj.addProperty(
+            "App::PropertyPythonObject", "Bin", "base", "python gridfinity object"
+        )
 
         self.add_bin_properties(obj)
         self.add_custom_bin_properties(obj)
@@ -154,22 +175,41 @@ class BinBlank(FoundationGridfinity):
         obj.Proxy = self
 
     def add_bin_properties(self, obj):
-
         obj.addProperty(
-            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+            "App::PropertyInteger",
+            "xGridUnits",
+            "Gridfinity",
+            "Length of the edges of the outline",
         ).xGridUnits = 2
-        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
         obj.addProperty(
-            "App::PropertyInteger", "HeightUnits", "Gridfinity", "Height of the bin in units, each is 7 mm"
+            "App::PropertyInteger",
+            "yGridUnits",
+            "Gridfinity",
+            "Height of the extrusion",
+        ).yGridUnits = 2
+        obj.addProperty(
+            "App::PropertyInteger",
+            "HeightUnits",
+            "Gridfinity",
+            "Height of the bin in units, each is 7 mm",
         ).HeightUnits = 6
         obj.addProperty(
-            "App::PropertyBool", "StackingLip", "Gridfinity", "Toggle the stacking lip on or off"
+            "App::PropertyBool",
+            "StackingLip",
+            "Gridfinity",
+            "Toggle the stacking lip on or off",
         ).StackingLip = True
         obj.addProperty(
-            "App::PropertyBool", "MagnetHoles", "Gridfinity", "Toggle the magnet holes on or off"
+            "App::PropertyBool",
+            "MagnetHoles",
+            "Gridfinity",
+            "Toggle the magnet holes on or off",
         ).MagnetHoles = True
         obj.addProperty(
-            "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
+            "App::PropertyBool",
+            "ScrewHoles",
+            "Gridfinity",
+            "Toggle the screw holes on or off",
         ).ScrewHoles = False
 
     def add_custom_bin_properties(self, obj):
@@ -186,7 +226,10 @@ class BinBlank(FoundationGridfinity):
             "Layer Height that you print in for optimal print results",
         ).SequentialBridgingLayerHeight = 0.2
         obj.addProperty(
-            "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
+            "App::PropertyBool",
+            "NonStandardHeight",
+            "GridfinityNonStandard",
+            "use a custom height if selected",
         ).NonStandardHeight = False
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -222,12 +265,26 @@ class BinBlank(FoundationGridfinity):
 
     def add_reference_properties(self, obj):
         obj.addProperty(
-            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+            "App::PropertyLength",
+            "xTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in x direction",
+            1,
         )
         obj.addProperty(
-            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+            "App::PropertyLength",
+            "yTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in y direction",
+            1,
         )
-        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the bin", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "TotalHeight",
+            "ReferenceDimensions",
+            "total height of the bin",
+            1,
+        )
         obj.addProperty(
             "App::PropertyLength",
             "BaseProfileHeight",
@@ -236,7 +293,11 @@ class BinBlank(FoundationGridfinity):
             1,
         )
         obj.addProperty(
-            "App::PropertyLength", "BinUnit", "ReferenceDimensions", "Width of a single bin unit", 1
+            "App::PropertyLength",
+            "BinUnit",
+            "ReferenceDimensions",
+            "Width of a single bin unit",
+            1,
         ).BinUnit = BIN_UNIT
 
     def add_expert_properties(self, obj):
@@ -261,18 +322,36 @@ class BinBlank(FoundationGridfinity):
             "Height of the top chamfer in the bin base profile",
             1,
         ).BaseProfileTopChamfer = BIN_BASE_TOP_CHAMFER
-        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
         obj.addProperty(
-            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+            "App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid"
+        ).GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength",
+            "HeightUnitValue",
+            "zzExpertOnly",
+            "height per unit, default is 7mm",
+            1,
         ).HeightUnitValue = 7
         obj.addProperty(
-            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the bin", 1
+            "App::PropertyLength",
+            "BinOuterRadius",
+            "zzExpertOnly",
+            "Outer radius of the bin",
+            1,
         ).BinOuterRadius = BIN_OUTER_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section", 1
+            "App::PropertyLength",
+            "BinVerticalRadius",
+            "zzExpertOnly",
+            "Radius of the base profile Vertical section",
+            1,
         ).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius", 1
+            "App::PropertyLength",
+            "BinBottomRadius",
+            "zzExpertOnly",
+            "bottom of bin corner radius",
+            1,
         ).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
 
         obj.addProperty(
@@ -297,7 +376,11 @@ class BinBlank(FoundationGridfinity):
             1,
         ).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
         obj.addProperty(
-            "App::PropertyLength", "StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip", 1
+            "App::PropertyLength",
+            "StackingLipTopChamfer",
+            "zzExpertOnly",
+            "Top Chamfer of the Stacking lip",
+            1,
         )
         obj.addProperty(
             "App::PropertyLength",
@@ -316,18 +399,24 @@ class BinBlank(FoundationGridfinity):
 
     def add_hidden_properties(self, obj):
         obj.addProperty(
-            "App::PropertyLength", "WallThickness", "GridfinityNonStandard", "for stacking lip"
+            "App::PropertyLength",
+            "WallThickness",
+            "GridfinityNonStandard",
+            "for stacking lip",
         ).WallThickness = 1
         obj.setEditorMode("WallThickness", 2)
 
     def generate_gridfinity_shape(self, obj):
-
         obj.xTotalWidth = obj.xGridUnits * obj.GridSize - obj.Tolerance * 2
         obj.yTotalWidth = obj.yGridUnits * obj.GridSize - obj.Tolerance * 2
         obj.BaseProfileHeight = (
-            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+            obj.BaseProfileBottomChamfer
+            + obj.BaseProfileVerticalSection
+            + obj.BaseProfileTopChamfer
         )
-        obj.StackingLipTopChamfer = obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
+        obj.StackingLipTopChamfer = (
+            obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
+        )
         obj.BinUnit = obj.GridSize - TOLERANCE * 2 * unitmm
 
         if obj.NonStandardHeight:
@@ -344,7 +433,11 @@ class BinBlank(FoundationGridfinity):
             obj.BinOuterRadius,
         )
         solid_center.translate(
-            App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0)
+            App.Vector(
+                obj.xTotalWidth / 2 - obj.BinUnit / 2,
+                obj.yTotalWidth / 2 - obj.BinUnit / 2,
+                0,
+            )
         )
 
         fuse_total = Part.Shape.fuse(fuse_total, solid_center)
@@ -366,11 +459,12 @@ class BinBlank(FoundationGridfinity):
 
 
 class BinBase(FoundationGridfinity):
-
     def __init__(self, obj):
         super(BinBase, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
+        obj.addProperty(
+            "App::PropertyPythonObject", "Bin", "base", "python gridfinity object"
+        )
 
         self.add_bin_properties(obj)
         self.add_custom_bin_properties(obj)
@@ -381,22 +475,41 @@ class BinBase(FoundationGridfinity):
         obj.Proxy = self
 
     def add_bin_properties(self, obj):
-
         obj.addProperty(
-            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+            "App::PropertyInteger",
+            "xGridUnits",
+            "Gridfinity",
+            "Length of the edges of the outline",
         ).xGridUnits = 2
-        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
         obj.addProperty(
-            "App::PropertyInteger", "HeightUnits", "Gridfinity", "height of the bin in units, each is 7 mm"
+            "App::PropertyInteger",
+            "yGridUnits",
+            "Gridfinity",
+            "Height of the extrusion",
+        ).yGridUnits = 2
+        obj.addProperty(
+            "App::PropertyInteger",
+            "HeightUnits",
+            "Gridfinity",
+            "height of the bin in units, each is 7 mm",
         ).HeightUnits = 1
         obj.addProperty(
-            "App::PropertyBool", "StackingLip", "Gridfinity", "Toggle the stacking lip on or off"
+            "App::PropertyBool",
+            "StackingLip",
+            "Gridfinity",
+            "Toggle the stacking lip on or off",
         ).StackingLip = False
         obj.addProperty(
-            "App::PropertyBool", "MagnetHoles", "Gridfinity", "Toggle the magnet holes on or off"
+            "App::PropertyBool",
+            "MagnetHoles",
+            "Gridfinity",
+            "Toggle the magnet holes on or off",
         ).MagnetHoles = True
         obj.addProperty(
-            "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
+            "App::PropertyBool",
+            "ScrewHoles",
+            "Gridfinity",
+            "Toggle the screw holes on or off",
         ).ScrewHoles = False
 
     def add_custom_bin_properties(self, obj):
@@ -413,7 +526,10 @@ class BinBase(FoundationGridfinity):
             "Layer Height that you print in for optimal print results",
         ).SequentialBridgingLayerHeight = 0.2
         obj.addProperty(
-            "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
+            "App::PropertyBool",
+            "NonStandardHeight",
+            "GridfinityNonStandard",
+            "use a custom height if selected",
         ).NonStandardHeight = False
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -449,12 +565,26 @@ class BinBase(FoundationGridfinity):
 
     def add_reference_properties(self, obj):
         obj.addProperty(
-            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+            "App::PropertyLength",
+            "xTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in x direction",
+            1,
         )
         obj.addProperty(
-            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+            "App::PropertyLength",
+            "yTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in y direction",
+            1,
         )
-        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the bin", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "TotalHeight",
+            "ReferenceDimensions",
+            "total height of the bin",
+            1,
+        )
         obj.addProperty(
             "App::PropertyLength",
             "BaseProfileHeight",
@@ -463,7 +593,11 @@ class BinBase(FoundationGridfinity):
             1,
         )
         obj.addProperty(
-            "App::PropertyLength", "BinUnit", "ReferenceDimensions", "Width of a single bin unit", 1
+            "App::PropertyLength",
+            "BinUnit",
+            "ReferenceDimensions",
+            "Width of a single bin unit",
+            1,
         ).BinUnit = BIN_UNIT
 
     def add_expert_properties(self, obj):
@@ -488,18 +622,36 @@ class BinBase(FoundationGridfinity):
             "Height of the top chamfer in the bin base profile",
             1,
         ).BaseProfileTopChamfer = BIN_BASE_TOP_CHAMFER
-        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
         obj.addProperty(
-            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+            "App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid"
+        ).GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength",
+            "HeightUnitValue",
+            "zzExpertOnly",
+            "height per unit, default is 7mm",
+            1,
         ).HeightUnitValue = 7
         obj.addProperty(
-            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the bin", 1
+            "App::PropertyLength",
+            "BinOuterRadius",
+            "zzExpertOnly",
+            "Outer radius of the bin",
+            1,
         ).BinOuterRadius = BIN_OUTER_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section", 1
+            "App::PropertyLength",
+            "BinVerticalRadius",
+            "zzExpertOnly",
+            "Radius of the base profile Vertical section",
+            1,
         ).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius", 1
+            "App::PropertyLength",
+            "BinBottomRadius",
+            "zzExpertOnly",
+            "bottom of bin corner radius",
+            1,
         ).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
 
         obj.addProperty(
@@ -524,7 +676,11 @@ class BinBase(FoundationGridfinity):
             1,
         ).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
         obj.addProperty(
-            "App::PropertyLength", "StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip", 1
+            "App::PropertyLength",
+            "StackingLipTopChamfer",
+            "zzExpertOnly",
+            "Top Chamfer of the Stacking lip",
+            1,
         )
         obj.addProperty(
             "App::PropertyLength",
@@ -543,18 +699,24 @@ class BinBase(FoundationGridfinity):
 
     def add_hidden_properties(self, obj):
         obj.addProperty(
-            "App::PropertyLength", "WallThickness", "GridfinityNonStandard", "for stacking lip"
+            "App::PropertyLength",
+            "WallThickness",
+            "GridfinityNonStandard",
+            "for stacking lip",
         ).WallThickness = 1
         obj.setEditorMode("WallThickness", 2)
 
     def generate_gridfinity_shape(self, obj):
-
         obj.xTotalWidth = obj.xGridUnits * obj.GridSize - obj.Tolerance * 2
         obj.yTotalWidth = obj.yGridUnits * obj.GridSize - obj.Tolerance * 2
         obj.BaseProfileHeight = (
-            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+            obj.BaseProfileBottomChamfer
+            + obj.BaseProfileVerticalSection
+            + obj.BaseProfileTopChamfer
         )
-        obj.StackingLipTopChamfer = obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
+        obj.StackingLipTopChamfer = (
+            obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
+        )
         obj.BinUnit = obj.GridSize - TOLERANCE * 2 * unitmm
 
         if obj.NonStandardHeight:
@@ -571,7 +733,11 @@ class BinBase(FoundationGridfinity):
             obj.BinOuterRadius,
         )
         solid_center.translate(
-            App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0)
+            App.Vector(
+                obj.xTotalWidth / 2 - obj.BinUnit / 2,
+                obj.yTotalWidth / 2 - obj.BinUnit / 2,
+                0,
+            )
         )
 
         fuse_total = Part.Shape.fuse(fuse_total, solid_center)
@@ -595,11 +761,12 @@ class BinBase(FoundationGridfinity):
 
 
 class SimpleStorageBin(FoundationGridfinity):
-
     def __init__(self, obj):
         super(SimpleStorageBin, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
+        obj.addProperty(
+            "App::PropertyPythonObject", "Bin", "base", "python gridfinity object"
+        )
 
         self.add_bin_properties(obj)
         self.add_custom_bin_properties(obj)
@@ -609,36 +776,72 @@ class SimpleStorageBin(FoundationGridfinity):
         obj.Proxy = self
 
     def add_bin_properties(self, obj):
-
         obj.addProperty(
-            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+            "App::PropertyInteger",
+            "xGridUnits",
+            "Gridfinity",
+            "Length of the edges of the outline",
         ).xGridUnits = 2
-        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
         obj.addProperty(
-            "App::PropertyInteger", "HeightUnits", "Gridfinity", "Height of the bin in units, each unit is 7 mm"
+            "App::PropertyInteger",
+            "yGridUnits",
+            "Gridfinity",
+            "Height of the extrusion",
+        ).yGridUnits = 2
+        obj.addProperty(
+            "App::PropertyInteger",
+            "HeightUnits",
+            "Gridfinity",
+            "Height of the bin in units, each unit is 7 mm",
         ).HeightUnits = 6
         obj.addProperty(
-            "App::PropertyBool", "StackingLip", "Gridfinity", "Toggle the stacking lip on or off"
+            "App::PropertyBool",
+            "StackingLip",
+            "Gridfinity",
+            "Toggle the stacking lip on or off",
         ).StackingLip = True
         obj.addProperty(
-            "App::PropertyBool", "MagnetHoles", "Gridfinity", "Toggle the magnet holes on or off"
+            "App::PropertyBool",
+            "MagnetHoles",
+            "Gridfinity",
+            "Toggle the magnet holes on or off",
         ).MagnetHoles = True
         obj.addProperty(
-            "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
+            "App::PropertyBool",
+            "ScrewHoles",
+            "Gridfinity",
+            "Toggle the screw holes on or off",
         ).ScrewHoles = False
-        obj.addProperty("App::PropertyBool", "Scoop", "Gridfinity", "Toggle the Scoop fillet on or off").Scoop = False
         obj.addProperty(
-            "App::PropertyInteger", "xDividers", "Gridfinity", "Select the Number of Dividers in the x direction"
+            "App::PropertyBool",
+            "Scoop",
+            "Gridfinity",
+            "Toggle the Scoop fillet on or off",
+        ).Scoop = False
+        obj.addProperty(
+            "App::PropertyInteger",
+            "xDividers",
+            "Gridfinity",
+            "Select the Number of Dividers in the x direction",
         ).xDividers = 0
         obj.addProperty(
-            "App::PropertyInteger", "yDividers", "Gridfinity", "Select the number of Dividers in the y direction"
+            "App::PropertyInteger",
+            "yDividers",
+            "Gridfinity",
+            "Select the number of Dividers in the y direction",
         ).yDividers = 0
         obj.addProperty(
-            "App::PropertyEnumeration", "LabelShelfPlacement", "Gridfinity", "Choose the style of the label shelf"
+            "App::PropertyEnumeration",
+            "LabelShelfPlacement",
+            "Gridfinity",
+            "Choose the style of the label shelf",
         )
         obj.LabelShelfPlacement = ["Center", "Full Width", "Left", "Right"]
         obj.addProperty(
-            "App::PropertyEnumeration", "LabelShelfStyle", "Gridfinity", "Choose to turn the label shelf on or off"
+            "App::PropertyEnumeration",
+            "LabelShelfStyle",
+            "Gridfinity",
+            "Choose to turn the label shelf on or off",
         )
         obj.LabelShelfStyle = ["Off", "Standard"]
 
@@ -656,7 +859,10 @@ class SimpleStorageBin(FoundationGridfinity):
             "Layer Height that you print in for optimal print results",
         ).SequentialBridgingLayerHeight = 0.2
         obj.addProperty(
-            "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
+            "App::PropertyBool",
+            "NonStandardHeight",
+            "GridfinityNonStandard",
+            "use a custom height if selected",
         ).NonStandardHeight = False
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -740,12 +946,26 @@ class SimpleStorageBin(FoundationGridfinity):
 
     def add_reference_properties(self, obj):
         obj.addProperty(
-            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+            "App::PropertyLength",
+            "xTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in x direction",
+            1,
         )
         obj.addProperty(
-            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+            "App::PropertyLength",
+            "yTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in y direction",
+            1,
         )
-        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the bin", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "TotalHeight",
+            "ReferenceDimensions",
+            "total height of the bin",
+            1,
+        )
         obj.addProperty(
             "App::PropertyLength",
             "BaseProfileHeight",
@@ -761,7 +981,11 @@ class SimpleStorageBin(FoundationGridfinity):
             1,
         )
         obj.addProperty(
-            "App::PropertyLength", "BinUnit", "ReferenceDimensions", "Width of a single bin unit", 1
+            "App::PropertyLength",
+            "BinUnit",
+            "ReferenceDimensions",
+            "Width of a single bin unit",
+            1,
         ).BinUnit = BIN_UNIT
 
     def add_expert_properties(self, obj):
@@ -786,18 +1010,36 @@ class SimpleStorageBin(FoundationGridfinity):
             "Height of the top chamfer in the bin base profile",
             1,
         ).BaseProfileTopChamfer = BIN_BASE_TOP_CHAMFER
-        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
         obj.addProperty(
-            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+            "App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid"
+        ).GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength",
+            "HeightUnitValue",
+            "zzExpertOnly",
+            "height per unit, default is 7mm",
+            1,
         ).HeightUnitValue = HEIGHT_UNIT
         obj.addProperty(
-            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the bin", 1
+            "App::PropertyLength",
+            "BinOuterRadius",
+            "zzExpertOnly",
+            "Outer radius of the bin",
+            1,
         ).BinOuterRadius = BIN_OUTER_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section", 1
+            "App::PropertyLength",
+            "BinVerticalRadius",
+            "zzExpertOnly",
+            "Radius of the base profile Vertical section",
+            1,
         ).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius", 1
+            "App::PropertyLength",
+            "BinBottomRadius",
+            "zzExpertOnly",
+            "bottom of bin corner radius",
+            1,
         ).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
 
         obj.addProperty(
@@ -822,7 +1064,11 @@ class SimpleStorageBin(FoundationGridfinity):
             1,
         ).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
         obj.addProperty(
-            "App::PropertyLength", "StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip", 1
+            "App::PropertyLength",
+            "StackingLipTopChamfer",
+            "zzExpertOnly",
+            "Top Chamfer of the Stacking lip",
+            1,
         )
         obj.addProperty(
             "App::PropertyLength",
@@ -846,15 +1092,18 @@ class SimpleStorageBin(FoundationGridfinity):
         ).LabelShelfVerticalThickness = LABEL_SHELF_VERTICAL_THICKNESS
 
     def generate_gridfinity_shape(self, obj):
-
         ## Parameter Calculations
 
         obj.xTotalWidth = obj.xGridUnits * obj.GridSize - obj.Tolerance * 2
         obj.yTotalWidth = obj.yGridUnits * obj.GridSize - obj.Tolerance * 2
         obj.BaseProfileHeight = (
-            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+            obj.BaseProfileBottomChamfer
+            + obj.BaseProfileVerticalSection
+            + obj.BaseProfileTopChamfer
         )
-        obj.StackingLipTopChamfer = obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
+        obj.StackingLipTopChamfer = (
+            obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
+        )
         obj.BinUnit = obj.GridSize - TOLERANCE * 2 * unitmm
 
         if obj.NonStandardHeight:
@@ -868,13 +1117,17 @@ class SimpleStorageBin(FoundationGridfinity):
         divmin = obj.HeightUnitValue + obj.InsideFilletRadius + 0.05 * unitmm
         if obj.xDividerHeight < divmin and obj.xDividerHeight != 0:
             obj.xDividerHeight = divmin
-            App.Console.PrintWarning("Divider Height must be equal to or greater than:  ")
+            App.Console.PrintWarning(
+                "Divider Height must be equal to or greater than:  "
+            )
             App.Console.PrintWarning(divmin)
             App.Console.PrintWarning("\n")
 
         if obj.yDividerHeight < divmin and obj.yDividerHeight != 0:
             obj.yDividerHeight = divmin
-            App.Console.PrintWarning("Divider Height must be equal to or greater than:  ")
+            App.Console.PrintWarning(
+                "Divider Height must be equal to or greater than:  "
+            )
             App.Console.PrintWarning(divmin)
             App.Console.PrintWarning("\n")
 
@@ -889,7 +1142,11 @@ class SimpleStorageBin(FoundationGridfinity):
             obj.BinOuterRadius,
         )
         solid_center.translate(
-            App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0)
+            App.Vector(
+                obj.xTotalWidth / 2 - obj.BinUnit / 2,
+                obj.yTotalWidth / 2 - obj.BinUnit / 2,
+                0,
+            )
         )
         fuse_total = fuse_total.fuse(solid_center)
 
@@ -927,11 +1184,12 @@ class SimpleStorageBin(FoundationGridfinity):
 
 
 class EcoBin(FoundationGridfinity):
-
     def __init__(self, obj):
         super(EcoBin, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
+        obj.addProperty(
+            "App::PropertyPythonObject", "Bin", "base", "python gridfinity object"
+        )
 
         self.add_bin_properties(obj)
         self.add_custom_bin_properties(obj)
@@ -941,29 +1199,54 @@ class EcoBin(FoundationGridfinity):
         obj.Proxy = self
 
     def add_bin_properties(self, obj):
-
         obj.addProperty(
-            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+            "App::PropertyInteger",
+            "xGridUnits",
+            "Gridfinity",
+            "Length of the edges of the outline",
         ).xGridUnits = 2
-        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
         obj.addProperty(
-            "App::PropertyInteger", "HeightUnits", "Gridfinity", "height of the bin in units, each unit is 7 mm"
+            "App::PropertyInteger",
+            "yGridUnits",
+            "Gridfinity",
+            "Height of the extrusion",
+        ).yGridUnits = 2
+        obj.addProperty(
+            "App::PropertyInteger",
+            "HeightUnits",
+            "Gridfinity",
+            "height of the bin in units, each unit is 7 mm",
         ).HeightUnits = 6
         obj.addProperty(
-            "App::PropertyBool", "StackingLip", "Gridfinity", "Toggle the stacking lip on or off"
+            "App::PropertyBool",
+            "StackingLip",
+            "Gridfinity",
+            "Toggle the stacking lip on or off",
         ).StackingLip = True
         obj.addProperty(
-            "App::PropertyBool", "MagnetHoles", "Gridfinity", "Toggle the magnet holes on or off"
+            "App::PropertyBool",
+            "MagnetHoles",
+            "Gridfinity",
+            "Toggle the magnet holes on or off",
         ).MagnetHoles = False
 
         obj.addProperty(
-            "App::PropertyInteger", "xDividers", "Gridfinity", "Select the Number of Dividers in the x direction"
+            "App::PropertyInteger",
+            "xDividers",
+            "Gridfinity",
+            "Select the Number of Dividers in the x direction",
         ).xDividers = 0
         obj.addProperty(
-            "App::PropertyInteger", "yDividers", "Gridfinity", "Select the number of Dividers in the y direction"
+            "App::PropertyInteger",
+            "yDividers",
+            "Gridfinity",
+            "Select the number of Dividers in the y direction",
         ).yDividers = 0
         obj.addProperty(
-            "App::PropertyLength", "BaseWallThickness", "Gridfinity", "The thickness of the bin at the base"
+            "App::PropertyLength",
+            "BaseWallThickness",
+            "Gridfinity",
+            "The thickness of the bin at the base",
         ).BaseWallThickness = 0.8
 
     def add_custom_bin_properties(self, obj):
@@ -980,7 +1263,10 @@ class EcoBin(FoundationGridfinity):
             "Layer Height that you print in for optimal print results",
         ).SequentialBridgingLayerHeight = 0.2
         obj.addProperty(
-            "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
+            "App::PropertyBool",
+            "NonStandardHeight",
+            "GridfinityNonStandard",
+            "use a custom height if selected",
         ).NonStandardHeight = False
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -1034,12 +1320,26 @@ class EcoBin(FoundationGridfinity):
 
     def add_reference_properties(self, obj):
         obj.addProperty(
-            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+            "App::PropertyLength",
+            "xTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in x direction",
+            1,
         )
         obj.addProperty(
-            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+            "App::PropertyLength",
+            "yTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in y direction",
+            1,
         )
-        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the bin", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "TotalHeight",
+            "ReferenceDimensions",
+            "total height of the bin",
+            1,
+        )
         obj.addProperty(
             "App::PropertyLength",
             "BaseProfileHeight",
@@ -1048,7 +1348,11 @@ class EcoBin(FoundationGridfinity):
             1,
         )
         obj.addProperty(
-            "App::PropertyLength", "BinUnit", "ReferenceDimensions", "Width of a single bin unit", 1
+            "App::PropertyLength",
+            "BinUnit",
+            "ReferenceDimensions",
+            "Width of a single bin unit",
+            1,
         ).BinUnit = BIN_UNIT
 
     def add_expert_properties(self, obj):
@@ -1073,18 +1377,36 @@ class EcoBin(FoundationGridfinity):
             "Height of the top chamfer in the bin base profile",
             1,
         ).BaseProfileTopChamfer = BIN_BASE_TOP_CHAMFER
-        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
         obj.addProperty(
-            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+            "App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid"
+        ).GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength",
+            "HeightUnitValue",
+            "zzExpertOnly",
+            "height per unit, default is 7mm",
+            1,
         ).HeightUnitValue = HEIGHT_UNIT
         obj.addProperty(
-            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the bin", 1
+            "App::PropertyLength",
+            "BinOuterRadius",
+            "zzExpertOnly",
+            "Outer radius of the bin",
+            1,
         ).BinOuterRadius = BIN_OUTER_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section", 1
+            "App::PropertyLength",
+            "BinVerticalRadius",
+            "zzExpertOnly",
+            "Radius of the base profile Vertical section",
+            1,
         ).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius", 1
+            "App::PropertyLength",
+            "BinBottomRadius",
+            "zzExpertOnly",
+            "bottom of bin corner radius",
+            1,
         ).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
 
         obj.addProperty(
@@ -1109,7 +1431,11 @@ class EcoBin(FoundationGridfinity):
             1,
         ).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
         obj.addProperty(
-            "App::PropertyLength", "StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip", 1
+            "App::PropertyLength",
+            "StackingLipTopChamfer",
+            "zzExpertOnly",
+            "Top Chamfer of the Stacking lip",
+            1,
         )
         obj.addProperty(
             "App::PropertyLength",
@@ -1127,7 +1453,10 @@ class EcoBin(FoundationGridfinity):
         ).StackingLipVerticalSection = STACKING_LIP_VERTICAL_SECTION
 
         obj.addProperty(
-            "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
+            "App::PropertyBool",
+            "ScrewHoles",
+            "Gridfinity",
+            "Toggle the screw holes on or off",
         ).ScrewHoles = False
         obj.setEditorMode("ScrewHoles", 2)
 
@@ -1152,9 +1481,13 @@ class EcoBin(FoundationGridfinity):
         obj.xTotalWidth = obj.xGridUnits * obj.GridSize - obj.Tolerance * 2
         obj.yTotalWidth = obj.yGridUnits * obj.GridSize - obj.Tolerance * 2
         obj.BaseProfileHeight = (
-            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+            obj.BaseProfileBottomChamfer
+            + obj.BaseProfileVerticalSection
+            + obj.BaseProfileTopChamfer
         )
-        obj.StackingLipTopChamfer = obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
+        obj.StackingLipTopChamfer = (
+            obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
+        )
         obj.BinUnit = obj.GridSize - TOLERANCE * 2 * unitmm
 
         if obj.NonStandardHeight:
@@ -1168,19 +1501,25 @@ class EcoBin(FoundationGridfinity):
         divmin = obj.HeightUnitValue + obj.InsideFilletRadius + 0.05 * unitmm
         if obj.xDividerHeight < divmin and obj.xDividerHeight != 0:
             obj.xDividerHeight = divmin
-            App.Console.PrintWarning("Divider Height must be equal to or greater than:  ")
+            App.Console.PrintWarning(
+                "Divider Height must be equal to or greater than:  "
+            )
             App.Console.PrintWarning(divmin)
             App.Console.PrintWarning("\n")
 
         if obj.yDividerHeight < divmin and obj.yDividerHeight != 0:
             obj.yDividerHeight = divmin
-            App.Console.PrintWarning("Divider Height must be equal to or greater than:  ")
+            App.Console.PrintWarning(
+                "Divider Height must be equal to or greater than:  "
+            )
             App.Console.PrintWarning(divmin)
             App.Console.PrintWarning("\n")
 
         if obj.InsideFilletRadius > (1.6 * unitmm):
             obj.InsideFilletRadius = 1.6 * unitmm
-            App.Console.PrintWarning("Inside Fillet Radius must be equal to or less than:  1.6 mm\n")
+            App.Console.PrintWarning(
+                "Inside Fillet Radius must be equal to or less than:  1.6 mm\n"
+            )
 
         ## Bin Construction
 
@@ -1194,7 +1533,11 @@ class EcoBin(FoundationGridfinity):
             obj.BinOuterRadius,
         )
         solid_center.translate(
-            App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0)
+            App.Vector(
+                obj.xTotalWidth / 2 - obj.BinUnit / 2,
+                obj.yTotalWidth / 2 - obj.BinUnit / 2,
+                0,
+            )
         )
         fuse_total = fuse_total.fuse(solid_center)
 
@@ -1222,11 +1565,12 @@ class EcoBin(FoundationGridfinity):
 
 
 class PartsBin(FoundationGridfinity):
-
     def __init__(self, obj):
         super(PartsBin, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
+        obj.addProperty(
+            "App::PropertyPythonObject", "Bin", "base", "python gridfinity object"
+        )
 
         self.add_bin_properties(obj)
         self.add_custom_bin_properties(obj)
@@ -1236,36 +1580,72 @@ class PartsBin(FoundationGridfinity):
         obj.Proxy = self
 
     def add_bin_properties(self, obj):
-
         obj.addProperty(
-            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+            "App::PropertyInteger",
+            "xGridUnits",
+            "Gridfinity",
+            "Length of the edges of the outline",
         ).xGridUnits = 2
-        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
         obj.addProperty(
-            "App::PropertyInteger", "HeightUnits", "Gridfinity", "height of the bin in units, each unit is 7 mm"
+            "App::PropertyInteger",
+            "yGridUnits",
+            "Gridfinity",
+            "Height of the extrusion",
+        ).yGridUnits = 2
+        obj.addProperty(
+            "App::PropertyInteger",
+            "HeightUnits",
+            "Gridfinity",
+            "height of the bin in units, each unit is 7 mm",
         ).HeightUnits = 6
         obj.addProperty(
-            "App::PropertyBool", "StackingLip", "Gridfinity", "Toggle the stacking lip on or off"
+            "App::PropertyBool",
+            "StackingLip",
+            "Gridfinity",
+            "Toggle the stacking lip on or off",
         ).StackingLip = True
         obj.addProperty(
-            "App::PropertyBool", "MagnetHoles", "Gridfinity", "Toggle the magnet holes on or off"
+            "App::PropertyBool",
+            "MagnetHoles",
+            "Gridfinity",
+            "Toggle the magnet holes on or off",
         ).MagnetHoles = True
         obj.addProperty(
-            "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
+            "App::PropertyBool",
+            "ScrewHoles",
+            "Gridfinity",
+            "Toggle the screw holes on or off",
         ).ScrewHoles = False
-        obj.addProperty("App::PropertyBool", "Scoop", "Gridfinity", "Toggle the Scoop fillet on or off").Scoop = True
         obj.addProperty(
-            "App::PropertyInteger", "xDividers", "Gridfinity", "Select the Number of Dividers in the x direction"
+            "App::PropertyBool",
+            "Scoop",
+            "Gridfinity",
+            "Toggle the Scoop fillet on or off",
+        ).Scoop = True
+        obj.addProperty(
+            "App::PropertyInteger",
+            "xDividers",
+            "Gridfinity",
+            "Select the Number of Dividers in the x direction",
         ).xDividers = 0
         obj.addProperty(
-            "App::PropertyInteger", "yDividers", "Gridfinity", "Select the number of Dividers in the y direction"
+            "App::PropertyInteger",
+            "yDividers",
+            "Gridfinity",
+            "Select the number of Dividers in the y direction",
         ).yDividers = 1
         obj.addProperty(
-            "App::PropertyEnumeration", "LabelShelfPlacement", "Gridfinity", "Choose the style of the label shelf"
+            "App::PropertyEnumeration",
+            "LabelShelfPlacement",
+            "Gridfinity",
+            "Choose the style of the label shelf",
         )
         obj.LabelShelfPlacement = ["Center", "Full Width", "Left", "Right"]
         obj.addProperty(
-            "App::PropertyEnumeration", "LabelShelfStyle", "Gridfinity", "Choose to turn the label shelf on or off"
+            "App::PropertyEnumeration",
+            "LabelShelfStyle",
+            "Gridfinity",
+            "Choose to turn the label shelf on or off",
         )
         obj.LabelShelfStyle = ["Standard", "Off"]
 
@@ -1283,7 +1663,10 @@ class PartsBin(FoundationGridfinity):
             "Layer Height that you print in for optimal print results",
         ).SequentialBridgingLayerHeight = 0.2
         obj.addProperty(
-            "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
+            "App::PropertyBool",
+            "NonStandardHeight",
+            "GridfinityNonStandard",
+            "use a custom height if selected",
         ).NonStandardHeight = False
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -1367,12 +1750,26 @@ class PartsBin(FoundationGridfinity):
 
     def add_reference_properties(self, obj):
         obj.addProperty(
-            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+            "App::PropertyLength",
+            "xTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in x direction",
+            1,
         )
         obj.addProperty(
-            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+            "App::PropertyLength",
+            "yTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in y direction",
+            1,
         )
-        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the bin", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "TotalHeight",
+            "ReferenceDimensions",
+            "total height of the bin",
+            1,
+        )
         obj.addProperty(
             "App::PropertyLength",
             "BaseProfileHeight",
@@ -1388,7 +1785,11 @@ class PartsBin(FoundationGridfinity):
             1,
         )
         obj.addProperty(
-            "App::PropertyLength", "BinUnit", "ReferenceDimensions", "Width of a single bin unit", 1
+            "App::PropertyLength",
+            "BinUnit",
+            "ReferenceDimensions",
+            "Width of a single bin unit",
+            1,
         ).BinUnit = BIN_UNIT
 
     def add_expert_properties(self, obj):
@@ -1413,18 +1814,36 @@ class PartsBin(FoundationGridfinity):
             "Height of the top chamfer in the bin base profile",
             1,
         ).BaseProfileTopChamfer = BIN_BASE_TOP_CHAMFER
-        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
         obj.addProperty(
-            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+            "App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid"
+        ).GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength",
+            "HeightUnitValue",
+            "zzExpertOnly",
+            "height per unit, default is 7mm",
+            1,
         ).HeightUnitValue = HEIGHT_UNIT
         obj.addProperty(
-            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the bin", 1
+            "App::PropertyLength",
+            "BinOuterRadius",
+            "zzExpertOnly",
+            "Outer radius of the bin",
+            1,
         ).BinOuterRadius = BIN_OUTER_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section", 1
+            "App::PropertyLength",
+            "BinVerticalRadius",
+            "zzExpertOnly",
+            "Radius of the base profile Vertical section",
+            1,
         ).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius", 1
+            "App::PropertyLength",
+            "BinBottomRadius",
+            "zzExpertOnly",
+            "bottom of bin corner radius",
+            1,
         ).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
 
         obj.addProperty(
@@ -1449,7 +1868,11 @@ class PartsBin(FoundationGridfinity):
             1,
         ).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
         obj.addProperty(
-            "App::PropertyLength", "StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip", 1
+            "App::PropertyLength",
+            "StackingLipTopChamfer",
+            "zzExpertOnly",
+            "Top Chamfer of the Stacking lip",
+            1,
         )
         obj.addProperty(
             "App::PropertyLength",
@@ -1473,15 +1896,18 @@ class PartsBin(FoundationGridfinity):
         ).LabelShelfVerticalThickness = LABEL_SHELF_VERTICAL_THICKNESS
 
     def generate_gridfinity_shape(self, obj):
-
         ## Calculated Properties
 
         obj.xTotalWidth = obj.xGridUnits * obj.GridSize - obj.Tolerance * 2
         obj.yTotalWidth = obj.yGridUnits * obj.GridSize - obj.Tolerance * 2
         obj.BaseProfileHeight = (
-            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+            obj.BaseProfileBottomChamfer
+            + obj.BaseProfileVerticalSection
+            + obj.BaseProfileTopChamfer
         )
-        obj.StackingLipTopChamfer = obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
+        obj.StackingLipTopChamfer = (
+            obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
+        )
         obj.BinUnit = obj.GridSize - TOLERANCE * 2 * unitmm
 
         if obj.NonStandardHeight:
@@ -1496,13 +1922,17 @@ class PartsBin(FoundationGridfinity):
         divmin = obj.HeightUnitValue + obj.InsideFilletRadius + 0.05 * unitmm
         if obj.xDividerHeight < divmin and obj.xDividerHeight != 0:
             obj.xDividerHeight = divmin
-            App.Console.PrintWarning("Divider Height must be equal to or greater than:  ")
+            App.Console.PrintWarning(
+                "Divider Height must be equal to or greater than:  "
+            )
             App.Console.PrintWarning(divmin)
             App.Console.PrintWarning("\n")
 
         if obj.yDividerHeight < divmin and obj.yDividerHeight != 0:
             obj.yDividerHeight = divmin
-            App.Console.PrintWarning("Divider Height must be equal to or greater than:  ")
+            App.Console.PrintWarning(
+                "Divider Height must be equal to or greater than:  "
+            )
             App.Console.PrintWarning(divmin)
             App.Console.PrintWarning("\n")
 
@@ -1513,7 +1943,9 @@ class PartsBin(FoundationGridfinity):
             and obj.xDividers != 0
         ):
             obj.LabelShelfStyle = "Off"
-            App.Console.PrintWarning("Label Shelf turned off for less than full height x dividers")
+            App.Console.PrintWarning(
+                "Label Shelf turned off for less than full height x dividers"
+            )
 
         ## Bin Construction
 
@@ -1527,7 +1959,11 @@ class PartsBin(FoundationGridfinity):
             obj.BinOuterRadius,
         )
         solid_center.translate(
-            App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0)
+            App.Vector(
+                obj.xTotalWidth / 2 - obj.BinUnit / 2,
+                obj.yTotalWidth / 2 - obj.BinUnit / 2,
+                0,
+            )
         )
         fuse_total = fuse_total.fuse(solid_center)
 
@@ -1563,11 +1999,12 @@ class PartsBin(FoundationGridfinity):
 
 
 class Baseplate(FoundationGridfinity):
-
     def __init__(self, obj):
         super(Baseplate, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
+        obj.addProperty(
+            "App::PropertyPythonObject", "Bin", "base", "python gridfinity object"
+        )
 
         self.add_bin_properties(obj)
         self.add_reference_properties(obj)
@@ -1576,20 +2013,41 @@ class Baseplate(FoundationGridfinity):
         obj.Proxy = self
 
     def add_bin_properties(self, obj):
-
         obj.addProperty(
-            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+            "App::PropertyInteger",
+            "xGridUnits",
+            "Gridfinity",
+            "Length of the edges of the outline",
         ).xGridUnits = 2
-        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
+        obj.addProperty(
+            "App::PropertyInteger",
+            "yGridUnits",
+            "Gridfinity",
+            "Height of the extrusion",
+        ).yGridUnits = 2
 
     def add_reference_properties(self, obj):
         obj.addProperty(
-            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+            "App::PropertyLength",
+            "xTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in x direction",
+            1,
         )
         obj.addProperty(
-            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+            "App::PropertyLength",
+            "yTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in y direction",
+            1,
         )
-        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the bin", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "TotalHeight",
+            "ReferenceDimensions",
+            "total height of the bin",
+            1,
+        )
         obj.addProperty(
             "App::PropertyLength",
             "BaseProfileHeight",
@@ -1621,14 +2079,28 @@ class Baseplate(FoundationGridfinity):
             1,
         ).BaseProfileTopChamfer = BASEPLATE_TOP_CHAMFER
         obj.addProperty(
-            "App::PropertyLength", "BaseplateProfileTotalHeight", "zzExpertOnly", "Height of the bin base profile", 1
+            "App::PropertyLength",
+            "BaseplateProfileTotalHeight",
+            "zzExpertOnly",
+            "Height of the bin base profile",
+            1,
         )
-        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
         obj.addProperty(
-            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+            "App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid"
+        ).GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength",
+            "HeightUnitValue",
+            "zzExpertOnly",
+            "height per unit, default is 7mm",
+            1,
         ).HeightUnitValue = 7
         obj.addProperty(
-            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the baseplate", 1
+            "App::PropertyLength",
+            "BinOuterRadius",
+            "zzExpertOnly",
+            "Outer radius of the baseplate",
+            1,
         ).BinOuterRadius = BASEPLATE_OUTER_RADIUS
         obj.addProperty(
             "App::PropertyLength",
@@ -1638,14 +2110,26 @@ class Baseplate(FoundationGridfinity):
             1,
         ).BinVerticalRadius = BASEPLATE_VERTICAL_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of baseplate corner radius", 1
+            "App::PropertyLength",
+            "BinBottomRadius",
+            "zzExpertOnly",
+            "bottom of baseplate corner radius",
+            1,
         ).BinBottomRadius = BASEPLATE_BOTTOM_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BaseplateTopLedgeWidth", "zzExpertOnly", "Top ledge of baseplate", 1
+            "App::PropertyLength",
+            "BaseplateTopLedgeWidth",
+            "zzExpertOnly",
+            "Top ledge of baseplate",
+            1,
         ).BaseplateTopLedgeWidth = BASEPLATE_TOP_LEDGE_WIDTH
-        obj.addProperty("App::PropertyLength", "BinUnit", "zzExpertOnly", "Width of a single bin unit", 2).BinUnit = (
-            BIN_UNIT
-        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "BinUnit",
+            "zzExpertOnly",
+            "Width of a single bin unit",
+            2,
+        ).BinUnit = BIN_UNIT
         obj.addProperty(
             "App::PropertyLength",
             "Tolerance",
@@ -1662,21 +2146,30 @@ class Baseplate(FoundationGridfinity):
         ).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
 
     def generate_gridfinity_shape(self, obj):
-
         obj.xTotalWidth = obj.xGridUnits * obj.GridSize
         obj.yTotalWidth = obj.yGridUnits * obj.GridSize
         obj.BaseProfileHeight = (
-            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+            obj.BaseProfileBottomChamfer
+            + obj.BaseProfileVerticalSection
+            + obj.BaseProfileTopChamfer
         )
         obj.TotalHeight = obj.BaseProfileHeight
         obj.BinUnit = obj.GridSize - obj.BaseplateTopLedgeWidth * 2
 
         fuse_total = MakeBinBase(self, obj)
         solid_center = RoundedRectangleExtrude(
-            obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight, obj.TotalHeight, obj.BinOuterRadius
+            obj.xTotalWidth,
+            obj.yTotalWidth,
+            -obj.TotalHeight,
+            obj.TotalHeight,
+            obj.BinOuterRadius,
         )
         solid_center.translate(
-            App.Vector(obj.xTotalWidth / 2 - obj.GridSize / 2, obj.yTotalWidth / 2 - obj.GridSize / 2, 0)
+            App.Vector(
+                obj.xTotalWidth / 2 - obj.GridSize / 2,
+                obj.yTotalWidth / 2 - obj.GridSize / 2,
+                0,
+            )
         )
         fuse_total = Part.Shape.cut(solid_center, fuse_total)
 
@@ -1690,11 +2183,12 @@ class Baseplate(FoundationGridfinity):
 
 
 class MagnetBaseplate(FoundationGridfinity):
-
     def __init__(self, obj):
         super(MagnetBaseplate, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
+        obj.addProperty(
+            "App::PropertyPythonObject", "Bin", "base", "python gridfinity object"
+        )
 
         self.add_bin_properties(obj)
         self.add_reference_properties(obj)
@@ -1705,21 +2199,44 @@ class MagnetBaseplate(FoundationGridfinity):
         obj.Proxy = self
 
     def add_bin_properties(self, obj):
-
         obj.addProperty(
-            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+            "App::PropertyInteger",
+            "xGridUnits",
+            "Gridfinity",
+            "Length of the edges of the outline",
         ).xGridUnits = 2
-        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
-        obj.addProperty("App::PropertyBool", "MagnetHoles", "Gridfinity", "MagnetHoles").MagnetHoles = True
+        obj.addProperty(
+            "App::PropertyInteger",
+            "yGridUnits",
+            "Gridfinity",
+            "Height of the extrusion",
+        ).yGridUnits = 2
+        obj.addProperty(
+            "App::PropertyBool", "MagnetHoles", "Gridfinity", "MagnetHoles"
+        ).MagnetHoles = True
 
     def add_reference_properties(self, obj):
         obj.addProperty(
-            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+            "App::PropertyLength",
+            "xTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in x direction",
+            1,
         )
         obj.addProperty(
-            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+            "App::PropertyLength",
+            "yTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in y direction",
+            1,
         )
-        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the baseplate", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "TotalHeight",
+            "ReferenceDimensions",
+            "total height of the baseplate",
+            1,
+        )
         obj.addProperty(
             "App::PropertyLength",
             "BaseProfileHeight",
@@ -1742,7 +2259,10 @@ class MagnetBaseplate(FoundationGridfinity):
             "Diameter of Magnet Holes <br> <br> default = 6.5 mm",
         ).MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
         obj.addProperty(
-            "App::PropertyLength", "MagnetHoleDepth", "NonStandard", "Depth of Magnet Holes <br> <br> default = 2.4 mm"
+            "App::PropertyLength",
+            "MagnetHoleDepth",
+            "NonStandard",
+            "Depth of Magnet Holes <br> <br> default = 2.4 mm",
         ).MagnetHoleDepth = MAGNET_HOLE_DEPTH
         obj.addProperty(
             "App::PropertyLength",
@@ -1792,14 +2312,28 @@ class MagnetBaseplate(FoundationGridfinity):
             1,
         ).BaseProfileTopChamfer = BASEPLATE_TOP_CHAMFER
         obj.addProperty(
-            "App::PropertyLength", "BaseplateProfileTotalHeight", "zzExpertOnly", "Height of the bin base profile", 1
+            "App::PropertyLength",
+            "BaseplateProfileTotalHeight",
+            "zzExpertOnly",
+            "Height of the bin base profile",
+            1,
         )
-        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
         obj.addProperty(
-            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+            "App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid"
+        ).GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength",
+            "HeightUnitValue",
+            "zzExpertOnly",
+            "height per unit, default is 7mm",
+            1,
         ).HeightUnitValue = 7
         obj.addProperty(
-            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the baseplate", 1
+            "App::PropertyLength",
+            "BinOuterRadius",
+            "zzExpertOnly",
+            "Outer radius of the baseplate",
+            1,
         ).BinOuterRadius = BASEPLATE_OUTER_RADIUS
         obj.addProperty(
             "App::PropertyLength",
@@ -1809,14 +2343,26 @@ class MagnetBaseplate(FoundationGridfinity):
             1,
         ).BinVerticalRadius = BASEPLATE_VERTICAL_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of baseplate corner radius", 1
+            "App::PropertyLength",
+            "BinBottomRadius",
+            "zzExpertOnly",
+            "bottom of baseplate corner radius",
+            1,
         ).BinBottomRadius = BASEPLATE_BOTTOM_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BaseplateTopLedgeWidth", "zzExpertOnly", "Top ledge of baseplate", 1
+            "App::PropertyLength",
+            "BaseplateTopLedgeWidth",
+            "zzExpertOnly",
+            "Top ledge of baseplate",
+            1,
         ).BaseplateTopLedgeWidth = BASEPLATE_TOP_LEDGE_WIDTH
-        obj.addProperty("App::PropertyLength", "BinUnit", "zzExpertOnly", "Width of a single bin unit", 2).BinUnit = (
-            BIN_UNIT
-        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "BinUnit",
+            "zzExpertOnly",
+            "Width of a single bin unit",
+            2,
+        ).BinUnit = BIN_UNIT
         obj.addProperty(
             "App::PropertyLength",
             "Tolerance",
@@ -1842,13 +2388,14 @@ class MagnetBaseplate(FoundationGridfinity):
         obj.setEditorMode("BaseThickness", 2)
 
     def generate_gridfinity_shape(self, obj):
-
         obj.xTotalWidth = obj.xGridUnits * obj.GridSize
         obj.yTotalWidth = obj.yGridUnits * obj.GridSize
 
         # Bottom of Bin placement, used for ability to reuse previous features.
         obj.BaseProfileHeight = (
-            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+            obj.BaseProfileBottomChamfer
+            + obj.BaseProfileVerticalSection
+            + obj.BaseProfileTopChamfer
         )
 
         # actaully the total height of the baseplate
@@ -1860,10 +2407,18 @@ class MagnetBaseplate(FoundationGridfinity):
         fuse_total.translate(App.Vector(0, 0, obj.TotalHeight - obj.BaseProfileHeight))
 
         solid_center = RoundedRectangleExtrude(
-            obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight, obj.TotalHeight, obj.BinOuterRadius
+            obj.xTotalWidth,
+            obj.yTotalWidth,
+            -obj.TotalHeight,
+            obj.TotalHeight,
+            obj.BinOuterRadius,
         )
         solid_center.translate(
-            App.Vector(obj.xTotalWidth / 2 - obj.GridSize / 2, obj.yTotalWidth / 2 - obj.GridSize / 2, 0)
+            App.Vector(
+                obj.xTotalWidth / 2 - obj.GridSize / 2,
+                obj.yTotalWidth / 2 - obj.GridSize / 2,
+                0,
+            )
         )
         fuse_total = Part.Shape.cut(solid_center, fuse_total)
 
@@ -1883,11 +2438,12 @@ class MagnetBaseplate(FoundationGridfinity):
 
 
 class ScrewTogetherBaseplate(FoundationGridfinity):
-
     def __init__(self, obj):
         super(ScrewTogetherBaseplate, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
+        obj.addProperty(
+            "App::PropertyPythonObject", "Bin", "base", "python gridfinity object"
+        )
 
         self.add_bin_properties(obj)
         self.add_reference_properties(obj)
@@ -1897,20 +2453,41 @@ class ScrewTogetherBaseplate(FoundationGridfinity):
         obj.Proxy = self
 
     def add_bin_properties(self, obj):
-
         obj.addProperty(
-            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+            "App::PropertyInteger",
+            "xGridUnits",
+            "Gridfinity",
+            "Length of the edges of the outline",
         ).xGridUnits = 2
-        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
+        obj.addProperty(
+            "App::PropertyInteger",
+            "yGridUnits",
+            "Gridfinity",
+            "Height of the extrusion",
+        ).yGridUnits = 2
 
     def add_reference_properties(self, obj):
         obj.addProperty(
-            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+            "App::PropertyLength",
+            "xTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in x direction",
+            1,
         )
         obj.addProperty(
-            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+            "App::PropertyLength",
+            "yTotalWidth",
+            "ReferenceDimensions",
+            "total width of bin in y direction",
+            1,
         )
-        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the baseplate", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "TotalHeight",
+            "ReferenceDimensions",
+            "total height of the baseplate",
+            1,
+        )
         obj.addProperty(
             "App::PropertyLength",
             "BaseProfileHeight",
@@ -1933,7 +2510,10 @@ class ScrewTogetherBaseplate(FoundationGridfinity):
             "Diameter of Magnet Holes <br> <br> default = 6.5 mm",
         ).MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
         obj.addProperty(
-            "App::PropertyLength", "MagnetHoleDepth", "NonStandard", "Depth of Magnet Holes <br> <br> default = 2.4 mm"
+            "App::PropertyLength",
+            "MagnetHoleDepth",
+            "NonStandard",
+            "Depth of Magnet Holes <br> <br> default = 2.4 mm",
         ).MagnetHoleDepth = MAGNET_HOLE_DEPTH
         obj.addProperty(
             "App::PropertyLength",
@@ -2001,14 +2581,28 @@ class ScrewTogetherBaseplate(FoundationGridfinity):
             1,
         ).BaseProfileTopChamfer = BASEPLATE_TOP_CHAMFER
         obj.addProperty(
-            "App::PropertyLength", "BaseplateProfileTotalHeight", "zzExpertOnly", "Height of the bin base profile", 1
+            "App::PropertyLength",
+            "BaseplateProfileTotalHeight",
+            "zzExpertOnly",
+            "Height of the bin base profile",
+            1,
         )
-        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
         obj.addProperty(
-            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+            "App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid"
+        ).GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength",
+            "HeightUnitValue",
+            "zzExpertOnly",
+            "height per unit, default is 7mm",
+            1,
         ).HeightUnitValue = 7
         obj.addProperty(
-            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the baseplate", 1
+            "App::PropertyLength",
+            "BinOuterRadius",
+            "zzExpertOnly",
+            "Outer radius of the baseplate",
+            1,
         ).BinOuterRadius = BASEPLATE_OUTER_RADIUS
         obj.addProperty(
             "App::PropertyLength",
@@ -2018,14 +2612,26 @@ class ScrewTogetherBaseplate(FoundationGridfinity):
             1,
         ).BinVerticalRadius = BASEPLATE_VERTICAL_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of baseplate corner radius", 1
+            "App::PropertyLength",
+            "BinBottomRadius",
+            "zzExpertOnly",
+            "bottom of baseplate corner radius",
+            1,
         ).BinBottomRadius = BASEPLATE_BOTTOM_RADIUS
         obj.addProperty(
-            "App::PropertyLength", "BaseplateTopLedgeWidth", "zzExpertOnly", "Top ledge of baseplate", 1
+            "App::PropertyLength",
+            "BaseplateTopLedgeWidth",
+            "zzExpertOnly",
+            "Top ledge of baseplate",
+            1,
         ).BaseplateTopLedgeWidth = BASEPLATE_TOP_LEDGE_WIDTH
-        obj.addProperty("App::PropertyLength", "BinUnit", "zzExpertOnly", "Width of a single bin unit", 2).BinUnit = (
-            BIN_UNIT
-        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "BinUnit",
+            "zzExpertOnly",
+            "Width of a single bin unit",
+            2,
+        ).BinUnit = BIN_UNIT
         obj.addProperty(
             "App::PropertyLength",
             "Tolerance",
@@ -2040,13 +2646,14 @@ class ScrewTogetherBaseplate(FoundationGridfinity):
         ).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
 
     def generate_gridfinity_shape(self, obj):
-
         obj.xTotalWidth = obj.xGridUnits * obj.GridSize
         obj.yTotalWidth = obj.yGridUnits * obj.GridSize
 
         # Bottom of Bin placement, used for ability to reuse previous features.
         obj.BaseProfileHeight = (
-            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+            obj.BaseProfileBottomChamfer
+            + obj.BaseProfileVerticalSection
+            + obj.BaseProfileTopChamfer
         )
 
         # actaully the total height of the baseplate
@@ -2058,10 +2665,18 @@ class ScrewTogetherBaseplate(FoundationGridfinity):
         fuse_total.translate(App.Vector(0, 0, obj.TotalHeight - obj.BaseProfileHeight))
 
         solid_center = RoundedRectangleExtrude(
-            obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight, obj.TotalHeight, obj.BinOuterRadius
+            obj.xTotalWidth,
+            obj.yTotalWidth,
+            -obj.TotalHeight,
+            obj.TotalHeight,
+            obj.BinOuterRadius,
         )
         solid_center.translate(
-            App.Vector(obj.xTotalWidth / 2 - obj.GridSize / 2, obj.yTotalWidth / 2 - obj.GridSize / 2, 0)
+            App.Vector(
+                obj.xTotalWidth / 2 - obj.GridSize / 2,
+                obj.yTotalWidth / 2 - obj.GridSize / 2,
+                0,
+            )
         )
         fuse_total = Part.Shape.cut(solid_center, fuse_total)
 

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -4,26 +4,76 @@ import FreeCAD as App
 import Part
 from FreeCAD import Units
 from .version import __version__
-from .feature_construction import MakeStackingLip, MakeBinBase, RoundedRectangleExtrude, MakeBottomHoles, MakeBaseplateCenterCut, MakeCompartements, MakeEcoBinCut, MakeScoop, MakeLabelShelf
+from .feature_construction import (
+    MakeStackingLip,
+    MakeBinBase,
+    RoundedRectangleExtrude,
+    MakeBottomHoles,
+    MakeBaseplateCenterCut,
+    MakeCompartements,
+    MakeEcoBinCut,
+    MakeScoop,
+    MakeLabelShelf,
+)
 from .baseplate_feature_construction import MakeBaseplateMagnetHoles, MakeBPScrewBottomCham, MakeBPConnectionHoles
-from .const import BIN_BASE_TOP_CHAMFER, BIN_BASE_BOTTOM_CHAMFER, BIN_BASE_VERTICAL_SECTION, GRID_SIZE, BIN_OUTER_RADIUS, BIN_UNIT, BIN_BASE_VERTICAL_RADIUS, BIN_BASE_BOTTOM_RADIUS, TOLERANCE, MAGNET_HOLE_DIAMETER, MAGNET_HOLE_DEPTH, MAGNET_HOLE_DISTANCE_FROM_EDGE, SCREW_HOLE_DIAMETER, SCREW_HOLE_DEPTH, BASEPLATE_BOTTOM_CHAMFER, BASEPLATE_VERTICAL_SECTION, BASEPLATE_TOP_CHAMFER, BASEPLATE_TOP_LEDGE_WIDTH, BASEPLATE_OUTER_RADIUS, BASEPLATE_VERTICAL_RADIUS, BASEPLATE_BOTTOM_RADIUS, STACKING_LIP_TOP_LEDGE,STACKING_LIP_BOTTOM_CHAMFER,STACKING_LIP_VERTICAL_SECTION, HEIGHT_UNIT, BASEPLATE_SMALL_FILLET, MAGNET_BASE, MAGNET_EDGE_THICKNESS, MAGNET_BASE_HOLE, MAGNET_CHAMFER, BASE_THICKNESS, MAGNET_BOTTOM_CHAMFER, CONNECTION_HOLE_DIAMETER, LABEL_SHELF_WIDTH, LABEL_SHELF_VERTICAL_THICKNESS, LABEL_SHELF_LENGTH, SCOOP_RADIUS
+from .const import (
+    BIN_BASE_TOP_CHAMFER,
+    BIN_BASE_BOTTOM_CHAMFER,
+    BIN_BASE_VERTICAL_SECTION,
+    GRID_SIZE,
+    BIN_OUTER_RADIUS,
+    BIN_UNIT,
+    BIN_BASE_VERTICAL_RADIUS,
+    BIN_BASE_BOTTOM_RADIUS,
+    TOLERANCE,
+    MAGNET_HOLE_DIAMETER,
+    MAGNET_HOLE_DEPTH,
+    MAGNET_HOLE_DISTANCE_FROM_EDGE,
+    SCREW_HOLE_DIAMETER,
+    SCREW_HOLE_DEPTH,
+    BASEPLATE_BOTTOM_CHAMFER,
+    BASEPLATE_VERTICAL_SECTION,
+    BASEPLATE_TOP_CHAMFER,
+    BASEPLATE_TOP_LEDGE_WIDTH,
+    BASEPLATE_OUTER_RADIUS,
+    BASEPLATE_VERTICAL_RADIUS,
+    BASEPLATE_BOTTOM_RADIUS,
+    STACKING_LIP_TOP_LEDGE,
+    STACKING_LIP_BOTTOM_CHAMFER,
+    STACKING_LIP_VERTICAL_SECTION,
+    HEIGHT_UNIT,
+    BASEPLATE_SMALL_FILLET,
+    MAGNET_BASE,
+    MAGNET_EDGE_THICKNESS,
+    MAGNET_BASE_HOLE,
+    MAGNET_CHAMFER,
+    BASE_THICKNESS,
+    MAGNET_BOTTOM_CHAMFER,
+    CONNECTION_HOLE_DIAMETER,
+    LABEL_SHELF_WIDTH,
+    LABEL_SHELF_VERTICAL_THICKNESS,
+    LABEL_SHELF_LENGTH,
+    SCOOP_RADIUS,
+)
 
 unitmm = Units.Quantity("1 mm")
 
-__all__ = ["BinBlank",
-           "SimpleStorageBin",
-           "PartsBin",
-           "Baseplate",
-           "MagnetBaseplate",
-           "ScrewTogetherBaseplate",
-           "EcoBin"]
+__all__ = [
+    "BinBlank",
+    "SimpleStorageBin",
+    "PartsBin",
+    "Baseplate",
+    "MagnetBaseplate",
+    "ScrewTogetherBaseplate",
+    "EcoBin",
+]
 
 
 def fcvec(x):
     if len(x) == 2:
-        return(App.Vector(x[0], x[1], 0))
+        return App.Vector(x[0], x[1], 0)
     else:
-        return(App.Vector(x[0], x[1], x[2]))
+        return App.Vector(x[0], x[1], x[2])
 
 
 class ViewProviderGridfinity(object):
@@ -34,8 +84,9 @@ class ViewProviderGridfinity(object):
         dirname = os.path.dirname(__file__)
         self.icon_fn = icon_fn or os.path.join(dirname, "icons", "gridfinity_workbench_icon.svg")
         App.Console.PrintMessage("works until here\n")
+
     def _check_attr(self):
-        ''' Check for missing attributes. '''
+        """Check for missing attributes."""
         if not hasattr(self, "icon_fn"):
             setattr(self, "icon_fn", os.path.join(os.path.dirname(__file__), "icons", "gridfinity_workbench_icon.svg"))
 
@@ -54,11 +105,13 @@ class ViewProviderGridfinity(object):
         if state and "icon_fn" in state:
             self.icon_fn = state["icon_fn"]
 
+
 class FoundationGridfinity(object):
     def __init__(self, obj):
         obj.addProperty("App::PropertyString", "version", "version", "Gridfinity Workbench Version", 1)
         obj.version = __version__
         self.make_attachable(obj)
+
     def make_attachable(self, obj):
         # Needed to make this object attachable
         pass
@@ -67,7 +120,7 @@ class FoundationGridfinity(object):
         gridfinity_shape = self.generate_gridfinity_shape(fp)
         if hasattr(fp, "BaseFeature") and fp.BaseFeature is not None:
             # we're inside a PartDesign Body, thus need to fuse with the base feature
-            gridfinity_shape.Placement = fp.Placement # ensure the bin is placed correctly before fusing
+            gridfinity_shape.Placement = fp.Placement  # ensure the bin is placed correctly before fusing
             result_shape = fp.BaseFeature.Shape.fuse(gridfinity_shape)
             result_shape.transformShape(fp.Placement.inverse().toMatrix(), True)
             fp.Shape = result_shape
@@ -80,13 +133,13 @@ class FoundationGridfinity(object):
         """
         raise NotImplementedError("generate_gridfinity_shape not implemented")
 
+
 class BinBlank(FoundationGridfinity):
 
     def __init__(self, obj):
         super(BinBlank, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject",
-                        "Bin", "base", "python gridfinity object")
+        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
 
         self.add_bin_properties(obj)
         self.add_custom_bin_properties(obj)
@@ -98,74 +151,196 @@ class BinBlank(FoundationGridfinity):
 
     def add_bin_properties(self, obj):
 
-        obj.addProperty("App::PropertyInteger","xGridUnits","Gridfinity","Length of the edges of the outline").xGridUnits=2
-        obj.addProperty("App::PropertyInteger","yGridUnits","Gridfinity","Height of the extrusion").yGridUnits=2
-        obj.addProperty("App::PropertyInteger","HeightUnits","Gridfinity","height of the bin in units, each is 7 mm").HeightUnits=6
-        obj.addProperty("App::PropertyBool","StackingLip","Gridfinity","Toggle the stacking lip on or off").StackingLip=True
-        obj.addProperty("App::PropertyBool","MagnetHoles","Gridfinity","Toggle the magnet holes on or off").MagnetHoles = True
-        obj.addProperty("App::PropertyBool","ScrewHoles","Gridfinity","Toggle the screw holes on or off").ScrewHoles = True
-
+        obj.addProperty(
+            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+        ).xGridUnits = 2
+        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
+        obj.addProperty(
+            "App::PropertyInteger", "HeightUnits", "Gridfinity", "height of the bin in units, each is 7 mm"
+        ).HeightUnits = 6
+        obj.addProperty(
+            "App::PropertyBool", "StackingLip", "Gridfinity", "Toggle the stacking lip on or off"
+        ).StackingLip = True
+        obj.addProperty(
+            "App::PropertyBool", "MagnetHoles", "Gridfinity", "Toggle the magnet holes on or off"
+        ).MagnetHoles = True
+        obj.addProperty(
+            "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
+        ).ScrewHoles = True
 
     def add_custom_bin_properties(self, obj):
-        obj.addProperty("App::PropertyLength","CustomHeight","GridfinityNonStandard","total height of the bin using the custom heignt instead of incraments of 7 mm").CustomHeight = 42
-        obj.addProperty("App::PropertyLength","SequentialBridgingLayerHeight","GridfinityNonStandard","Layer Height that you print in for optimal print results").SequentialBridgingLayerHeight = 0.2
-        obj.addProperty("App::PropertyBool","NonStandardHeight","GridfinityNonStandard","use a custom height if selected").NonStandardHeight=False
-        obj.addProperty("App::PropertyLength","MagnetHoleDiameter", "GridfinityNonStandard", "Diameter of Magnet Holes <br> <br> default = 6.5 mm").MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
-        obj.addProperty("App::PropertyLength","MagnetHoleDepth", "GridfinityNonStandard", "Depth of Magnet Holes <br> <br> default = 2.4 mm").MagnetHoleDepth = MAGNET_HOLE_DEPTH
-        obj.addProperty("App::PropertyLength","ScrewHoleDiameter", "GridfinityNonStandard", "Diameter of Screw Holes <br> <br> default = 3.0 mm").ScrewHoleDiameter = SCREW_HOLE_DIAMETER
-        obj.addProperty("App::PropertyLength","ScrewHoleDepth", "GridfinityNonStandard", "Depth of Screw Holes <br> <br> default = 6.0 mm").ScrewHoleDepth = SCREW_HOLE_DEPTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "CustomHeight",
+            "GridfinityNonStandard",
+            "total height of the bin using the custom heignt instead of incraments of 7 mm",
+        ).CustomHeight = 42
+        obj.addProperty(
+            "App::PropertyLength",
+            "SequentialBridgingLayerHeight",
+            "GridfinityNonStandard",
+            "Layer Height that you print in for optimal print results",
+        ).SequentialBridgingLayerHeight = 0.2
+        obj.addProperty(
+            "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
+        ).NonStandardHeight = False
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDiameter",
+            "GridfinityNonStandard",
+            "Diameter of Magnet Holes <br> <br> default = 6.5 mm",
+        ).MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDepth",
+            "GridfinityNonStandard",
+            "Depth of Magnet Holes <br> <br> default = 2.4 mm",
+        ).MagnetHoleDepth = MAGNET_HOLE_DEPTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "ScrewHoleDiameter",
+            "GridfinityNonStandard",
+            "Diameter of Screw Holes <br> <br> default = 3.0 mm",
+        ).ScrewHoleDiameter = SCREW_HOLE_DIAMETER
+        obj.addProperty(
+            "App::PropertyLength",
+            "ScrewHoleDepth",
+            "GridfinityNonStandard",
+            "Depth of Screw Holes <br> <br> default = 6.0 mm",
+        ).ScrewHoleDepth = SCREW_HOLE_DEPTH
 
     def add_reference_properties(self, obj):
-        obj.addProperty("App::PropertyLength","xTotalWidth","ReferenceDimensions","total width of bin in x direction", 1)
-        obj.addProperty("App::PropertyLength","yTotalWidth","ReferenceDimensions","total width of bin in y direction", 1)
-        obj.addProperty("App::PropertyLength","TotalHeight","ReferenceDimensions","total height of the bin", 1)
-        obj.addProperty("App::PropertyLength","BaseProfileHeight","ReferenceDimensions","Height of the Gridfinity Base Profile", 1)
-        obj.addProperty("App::PropertyLength","BinUnit", "ReferenceDimensions", "Width of a single bin unit",1).BinUnit = BIN_UNIT
+        obj.addProperty(
+            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+        )
+        obj.addProperty(
+            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+        )
+        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the bin", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileHeight",
+            "ReferenceDimensions",
+            "Height of the Gridfinity Base Profile",
+            1,
+        )
+        obj.addProperty(
+            "App::PropertyLength", "BinUnit", "ReferenceDimensions", "Width of a single bin unit", 1
+        ).BinUnit = BIN_UNIT
 
     def add_expert_properties(self, obj):
-        obj.addProperty("App::PropertyLength","BaseProfileBottomChamfer", "zzExpertOnly", "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",1).BaseProfileBottomChamfer=BIN_BASE_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","BaseProfileVerticalSection", "zzExpertOnly", "Height of the vertical section in bin base profile",1).BaseProfileVerticalSection=BIN_BASE_VERTICAL_SECTION
-        obj.addProperty("App::PropertyLength","BaseProfileTopChamfer", "zzExpertOnly", "Height of the top chamfer in the bin base profile",1).BaseProfileTopChamfer=BIN_BASE_TOP_CHAMFER
-        obj.addProperty("App::PropertyLength","GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
-        obj.addProperty("App::PropertyLength","HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm",1).HeightUnitValue = 7
-        obj.addProperty("App::PropertyLength","BinOuterRadius", "zzExpertOnly", "Outer radius of the bin",1).BinOuterRadius = BIN_OUTER_RADIUS
-        obj.addProperty("App::PropertyLength","BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section",1).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
-        obj.addProperty("App::PropertyLength","BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius",1).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileBottomChamfer",
+            "zzExpertOnly",
+            "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",
+            1,
+        ).BaseProfileBottomChamfer = BIN_BASE_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileVerticalSection",
+            "zzExpertOnly",
+            "Height of the vertical section in bin base profile",
+            1,
+        ).BaseProfileVerticalSection = BIN_BASE_VERTICAL_SECTION
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileTopChamfer",
+            "zzExpertOnly",
+            "Height of the top chamfer in the bin base profile",
+            1,
+        ).BaseProfileTopChamfer = BIN_BASE_TOP_CHAMFER
+        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+        ).HeightUnitValue = 7
+        obj.addProperty(
+            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the bin", 1
+        ).BinOuterRadius = BIN_OUTER_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section", 1
+        ).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius", 1
+        ).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
 
-        obj.addProperty("App::PropertyLength","Tolerance", "zzExpertOnly", "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",1).Tolerance = TOLERANCE
-        obj.addProperty("App::PropertyLength","MagnetHoleDistanceFromEdge", "zzExpertOnly", "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",1).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
-        obj.addProperty("App::PropertyLength","StackingLipTopLedge", "zzExpertOnly", "Top Ledge of the stacking lip <br> <br> default = 0.4 mm",1).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
-        obj.addProperty("App::PropertyLength","StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip",1)
-        obj.addProperty("App::PropertyLength","StackingLipBottomChamfer", "zzExpertOnly", "Bottom Chamfer of the Stacking lip<br> <br> default = 0.7 mm",1).StackingLipBottomChamfer = STACKING_LIP_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","StackingLipVerticalSection", "zzExpertOnly", "vertical section of the Stacking lip<br> <br> default = 1.8 mm",1).StackingLipVerticalSection= STACKING_LIP_VERTICAL_SECTION
+        obj.addProperty(
+            "App::PropertyLength",
+            "Tolerance",
+            "zzExpertOnly",
+            "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",
+            1,
+        ).Tolerance = TOLERANCE
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDistanceFromEdge",
+            "zzExpertOnly",
+            "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",
+            1,
+        ).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipTopLedge",
+            "zzExpertOnly",
+            "Top Ledge of the stacking lip <br> <br> default = 0.4 mm",
+            1,
+        ).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
+        obj.addProperty(
+            "App::PropertyLength", "StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip", 1
+        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipBottomChamfer",
+            "zzExpertOnly",
+            "Bottom Chamfer of the Stacking lip<br> <br> default = 0.7 mm",
+            1,
+        ).StackingLipBottomChamfer = STACKING_LIP_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipVerticalSection",
+            "zzExpertOnly",
+            "vertical section of the Stacking lip<br> <br> default = 1.8 mm",
+            1,
+        ).StackingLipVerticalSection = STACKING_LIP_VERTICAL_SECTION
 
     def add_hidden_properties(self, obj):
-        obj.addProperty("App::PropertyLength","WallThickness", "GridfinityNonStandard", "for stacking lip").WallThickness = 1
-        obj.setEditorMode("WallThickness",2)
+        obj.addProperty(
+            "App::PropertyLength", "WallThickness", "GridfinityNonStandard", "for stacking lip"
+        ).WallThickness = 1
+        obj.setEditorMode("WallThickness", 2)
 
     def generate_gridfinity_shape(self, obj):
 
-        obj.xTotalWidth = obj.xGridUnits*obj.GridSize-obj.Tolerance*2
-        obj.yTotalWidth = obj.yGridUnits*obj.GridSize-obj.Tolerance*2
-        obj.BaseProfileHeight = obj.BaseProfileBottomChamfer+obj.BaseProfileVerticalSection+obj.BaseProfileTopChamfer
+        obj.xTotalWidth = obj.xGridUnits * obj.GridSize - obj.Tolerance * 2
+        obj.yTotalWidth = obj.yGridUnits * obj.GridSize - obj.Tolerance * 2
+        obj.BaseProfileHeight = (
+            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+        )
         obj.StackingLipTopChamfer = obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
-        obj.BinUnit = obj.GridSize - TOLERANCE*2*unitmm
+        obj.BinUnit = obj.GridSize - TOLERANCE * 2 * unitmm
 
         if obj.NonStandardHeight:
             obj.TotalHeight = obj.CustomHeight
         else:
-            obj.TotalHeight = obj.HeightUnits*obj.HeightUnitValue
-
+            obj.TotalHeight = obj.HeightUnits * obj.HeightUnitValue
 
         fuse_total = MakeBinBase(self, obj)
-        solid_center= RoundedRectangleExtrude(obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight+obj.BaseProfileHeight, obj.TotalHeight-obj.BaseProfileHeight, obj.BinOuterRadius)
-        solid_center.translate(App.Vector(obj.xTotalWidth/2-obj.BinUnit/2,obj.yTotalWidth/2-obj.BinUnit/2,0))
+        solid_center = RoundedRectangleExtrude(
+            obj.xTotalWidth,
+            obj.yTotalWidth,
+            -obj.TotalHeight + obj.BaseProfileHeight,
+            obj.TotalHeight - obj.BaseProfileHeight,
+            obj.BinOuterRadius,
+        )
+        solid_center.translate(
+            App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0)
+        )
 
-        fuse_total = Part.Shape.fuse(fuse_total, solid_center )
+        fuse_total = Part.Shape.fuse(fuse_total, solid_center)
 
         if obj.StackingLip:
             stacking_lip = MakeStackingLip(self, obj)
-            fuse_total = Part.Shape.fuse(stacking_lip,fuse_total)
+            fuse_total = Part.Shape.fuse(stacking_lip, fuse_total)
         if obj.ScrewHoles or obj.MagnetHoles:
             holes = MakeBottomHoles(self, obj)
             fuse_total = Part.Shape.cut(fuse_total, holes)
@@ -184,8 +359,7 @@ class BinBase(FoundationGridfinity):
     def __init__(self, obj):
         super(BinBase, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject",
-                        "Bin", "base", "python gridfinity object")
+        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
 
         self.add_bin_properties(obj)
         self.add_custom_bin_properties(obj)
@@ -197,79 +371,201 @@ class BinBase(FoundationGridfinity):
 
     def add_bin_properties(self, obj):
 
-        obj.addProperty("App::PropertyInteger","xGridUnits","Gridfinity","Length of the edges of the outline").xGridUnits=2
-        obj.addProperty("App::PropertyInteger","yGridUnits","Gridfinity","Height of the extrusion").yGridUnits=2
-        obj.addProperty("App::PropertyInteger","HeightUnits","Gridfinity","height of the bin in units, each is 7 mm").HeightUnits=1
-        obj.addProperty("App::PropertyBool","StackingLip","Gridfinity","Toggle the stacking lip on or off").StackingLip=False
-        obj.addProperty("App::PropertyBool","MagnetHoles","Gridfinity","Toggle the magnet holes on or off").MagnetHoles = True
-        obj.addProperty("App::PropertyBool","ScrewHoles","Gridfinity","Toggle the screw holes on or off").ScrewHoles = True
-
+        obj.addProperty(
+            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+        ).xGridUnits = 2
+        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
+        obj.addProperty(
+            "App::PropertyInteger", "HeightUnits", "Gridfinity", "height of the bin in units, each is 7 mm"
+        ).HeightUnits = 1
+        obj.addProperty(
+            "App::PropertyBool", "StackingLip", "Gridfinity", "Toggle the stacking lip on or off"
+        ).StackingLip = False
+        obj.addProperty(
+            "App::PropertyBool", "MagnetHoles", "Gridfinity", "Toggle the magnet holes on or off"
+        ).MagnetHoles = True
+        obj.addProperty(
+            "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
+        ).ScrewHoles = True
 
     def add_custom_bin_properties(self, obj):
-        obj.addProperty("App::PropertyLength","CustomHeight","GridfinityNonStandard","total height of the bin using the custom heignt instead of incraments of 7 mm").CustomHeight = 42
-        obj.addProperty("App::PropertyLength","SequentialBridgingLayerHeight","GridfinityNonStandard","Layer Height that you print in for optimal print results").SequentialBridgingLayerHeight = 0.2
-        obj.addProperty("App::PropertyBool","NonStandardHeight","GridfinityNonStandard","use a custom height if selected").NonStandardHeight=False
-        obj.addProperty("App::PropertyLength","MagnetHoleDiameter", "GridfinityNonStandard", "Diameter of Magnet Holes <br> <br> default = 6.5 mm").MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
-        obj.addProperty("App::PropertyLength","MagnetHoleDepth", "GridfinityNonStandard", "Depth of Magnet Holes <br> <br> default = 2.4 mm").MagnetHoleDepth = MAGNET_HOLE_DEPTH
-        obj.addProperty("App::PropertyLength","ScrewHoleDiameter", "GridfinityNonStandard", "Diameter of Screw Holes <br> <br> default = 3.0 mm").ScrewHoleDiameter = SCREW_HOLE_DIAMETER
-        obj.addProperty("App::PropertyLength","ScrewHoleDepth", "GridfinityNonStandard", "Depth of Screw Holes <br> <br> default = 6.0 mm").ScrewHoleDepth = SCREW_HOLE_DEPTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "CustomHeight",
+            "GridfinityNonStandard",
+            "total height of the bin using the custom heignt instead of incraments of 7 mm",
+        ).CustomHeight = 42
+        obj.addProperty(
+            "App::PropertyLength",
+            "SequentialBridgingLayerHeight",
+            "GridfinityNonStandard",
+            "Layer Height that you print in for optimal print results",
+        ).SequentialBridgingLayerHeight = 0.2
+        obj.addProperty(
+            "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
+        ).NonStandardHeight = False
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDiameter",
+            "GridfinityNonStandard",
+            "Diameter of Magnet Holes <br> <br> default = 6.5 mm",
+        ).MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDepth",
+            "GridfinityNonStandard",
+            "Depth of Magnet Holes <br> <br> default = 2.4 mm",
+        ).MagnetHoleDepth = MAGNET_HOLE_DEPTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "ScrewHoleDiameter",
+            "GridfinityNonStandard",
+            "Diameter of Screw Holes <br> <br> default = 3.0 mm",
+        ).ScrewHoleDiameter = SCREW_HOLE_DIAMETER
+        obj.addProperty(
+            "App::PropertyLength",
+            "ScrewHoleDepth",
+            "GridfinityNonStandard",
+            "Depth of Screw Holes <br> <br> default = 6.0 mm",
+        ).ScrewHoleDepth = SCREW_HOLE_DEPTH
 
     def add_reference_properties(self, obj):
-        obj.addProperty("App::PropertyLength","xTotalWidth","ReferenceDimensions","total width of bin in x direction", 1)
-        obj.addProperty("App::PropertyLength","yTotalWidth","ReferenceDimensions","total width of bin in y direction", 1)
-        obj.addProperty("App::PropertyLength","TotalHeight","ReferenceDimensions","total height of the bin", 1)
-        obj.addProperty("App::PropertyLength","BaseProfileHeight","ReferenceDimensions","Height of the Gridfinity Base Profile", 1)
-        obj.addProperty("App::PropertyLength","BinUnit", "ReferenceDimensions", "Width of a single bin unit",1).BinUnit = BIN_UNIT
+        obj.addProperty(
+            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+        )
+        obj.addProperty(
+            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+        )
+        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the bin", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileHeight",
+            "ReferenceDimensions",
+            "Height of the Gridfinity Base Profile",
+            1,
+        )
+        obj.addProperty(
+            "App::PropertyLength", "BinUnit", "ReferenceDimensions", "Width of a single bin unit", 1
+        ).BinUnit = BIN_UNIT
 
     def add_expert_properties(self, obj):
-        obj.addProperty("App::PropertyLength","BaseProfileBottomChamfer", "zzExpertOnly", "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",1).BaseProfileBottomChamfer=BIN_BASE_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","BaseProfileVerticalSection", "zzExpertOnly", "Height of the vertical section in bin base profile",1).BaseProfileVerticalSection=BIN_BASE_VERTICAL_SECTION
-        obj.addProperty("App::PropertyLength","BaseProfileTopChamfer", "zzExpertOnly", "Height of the top chamfer in the bin base profile",1).BaseProfileTopChamfer=BIN_BASE_TOP_CHAMFER
-        obj.addProperty("App::PropertyLength","GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
-        obj.addProperty("App::PropertyLength","HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm",1).HeightUnitValue = 7
-        obj.addProperty("App::PropertyLength","BinOuterRadius", "zzExpertOnly", "Outer radius of the bin",1).BinOuterRadius = BIN_OUTER_RADIUS
-        obj.addProperty("App::PropertyLength","BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section",1).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
-        obj.addProperty("App::PropertyLength","BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius",1).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileBottomChamfer",
+            "zzExpertOnly",
+            "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",
+            1,
+        ).BaseProfileBottomChamfer = BIN_BASE_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileVerticalSection",
+            "zzExpertOnly",
+            "Height of the vertical section in bin base profile",
+            1,
+        ).BaseProfileVerticalSection = BIN_BASE_VERTICAL_SECTION
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileTopChamfer",
+            "zzExpertOnly",
+            "Height of the top chamfer in the bin base profile",
+            1,
+        ).BaseProfileTopChamfer = BIN_BASE_TOP_CHAMFER
+        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+        ).HeightUnitValue = 7
+        obj.addProperty(
+            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the bin", 1
+        ).BinOuterRadius = BIN_OUTER_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section", 1
+        ).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius", 1
+        ).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
 
-        obj.addProperty("App::PropertyLength","Tolerance", "zzExpertOnly", "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",1).Tolerance = TOLERANCE
-        obj.addProperty("App::PropertyLength","MagnetHoleDistanceFromEdge", "zzExpertOnly", "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",1).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
-        obj.addProperty("App::PropertyLength","StackingLipTopLedge", "zzExpertOnly", "Top Ledge of the stacking lip <br> <br> default = 0.4 mm",1).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
-        obj.addProperty("App::PropertyLength","StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip",1)
-        obj.addProperty("App::PropertyLength","StackingLipBottomChamfer", "zzExpertOnly", "Bottom Chamfer of the Stacking lip<br> <br> default = 0.7 mm",1).StackingLipBottomChamfer = STACKING_LIP_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","StackingLipVerticalSection", "zzExpertOnly", "vertical section of the Stacking lip<br> <br> default = 1.8 mm",1).StackingLipVerticalSection= STACKING_LIP_VERTICAL_SECTION
+        obj.addProperty(
+            "App::PropertyLength",
+            "Tolerance",
+            "zzExpertOnly",
+            "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",
+            1,
+        ).Tolerance = TOLERANCE
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDistanceFromEdge",
+            "zzExpertOnly",
+            "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",
+            1,
+        ).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipTopLedge",
+            "zzExpertOnly",
+            "Top Ledge of the stacking lip <br> <br> default = 0.4 mm",
+            1,
+        ).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
+        obj.addProperty(
+            "App::PropertyLength", "StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip", 1
+        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipBottomChamfer",
+            "zzExpertOnly",
+            "Bottom Chamfer of the Stacking lip<br> <br> default = 0.7 mm",
+            1,
+        ).StackingLipBottomChamfer = STACKING_LIP_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipVerticalSection",
+            "zzExpertOnly",
+            "vertical section of the Stacking lip<br> <br> default = 1.8 mm",
+            1,
+        ).StackingLipVerticalSection = STACKING_LIP_VERTICAL_SECTION
 
     def add_hidden_properties(self, obj):
-        obj.addProperty("App::PropertyLength","WallThickness", "GridfinityNonStandard", "for stacking lip").WallThickness = 1
-        obj.setEditorMode("WallThickness",2)
+        obj.addProperty(
+            "App::PropertyLength", "WallThickness", "GridfinityNonStandard", "for stacking lip"
+        ).WallThickness = 1
+        obj.setEditorMode("WallThickness", 2)
 
     def generate_gridfinity_shape(self, obj):
 
-        obj.xTotalWidth = obj.xGridUnits*obj.GridSize-obj.Tolerance*2
-        obj.yTotalWidth = obj.yGridUnits*obj.GridSize-obj.Tolerance*2
-        obj.BaseProfileHeight = obj.BaseProfileBottomChamfer+obj.BaseProfileVerticalSection+obj.BaseProfileTopChamfer
+        obj.xTotalWidth = obj.xGridUnits * obj.GridSize - obj.Tolerance * 2
+        obj.yTotalWidth = obj.yGridUnits * obj.GridSize - obj.Tolerance * 2
+        obj.BaseProfileHeight = (
+            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+        )
         obj.StackingLipTopChamfer = obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
-        obj.BinUnit = obj.GridSize - TOLERANCE*2*unitmm
+        obj.BinUnit = obj.GridSize - TOLERANCE * 2 * unitmm
 
         if obj.NonStandardHeight:
             obj.TotalHeight = obj.CustomHeight
         else:
-            obj.TotalHeight = obj.HeightUnits*obj.HeightUnitValue
-
+            obj.TotalHeight = obj.HeightUnits * obj.HeightUnitValue
 
         fuse_total = MakeBinBase(self, obj)
-        solid_center= RoundedRectangleExtrude(obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight+obj.BaseProfileHeight, obj.TotalHeight-obj.BaseProfileHeight, obj.BinOuterRadius)
-        solid_center.translate(App.Vector(obj.xTotalWidth/2-obj.BinUnit/2,obj.yTotalWidth/2-obj.BinUnit/2,0))
+        solid_center = RoundedRectangleExtrude(
+            obj.xTotalWidth,
+            obj.yTotalWidth,
+            -obj.TotalHeight + obj.BaseProfileHeight,
+            obj.TotalHeight - obj.BaseProfileHeight,
+            obj.BinOuterRadius,
+        )
+        solid_center.translate(
+            App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0)
+        )
 
-        fuse_total = Part.Shape.fuse(fuse_total, solid_center )
+        fuse_total = Part.Shape.fuse(fuse_total, solid_center)
 
         if obj.StackingLip:
             stacking_lip = MakeStackingLip(self, obj)
-            fuse_total = Part.Shape.fuse(stacking_lip,fuse_total)
+            fuse_total = Part.Shape.fuse(stacking_lip, fuse_total)
         if obj.ScrewHoles or obj.MagnetHoles:
             holes = MakeBottomHoles(self, obj)
             fuse_total = Part.Shape.cut(fuse_total, holes)
 
-        #fuse_total.translate(App.Vector(obj.BinUnit/2*4,obj.BinUnit/2*4,0))
+        # fuse_total.translate(App.Vector(obj.BinUnit/2*4,obj.BinUnit/2*4,0))
 
         return fuse_total
 
@@ -279,13 +575,13 @@ class BinBase(FoundationGridfinity):
     def __setstate__(self, state):
         return None
 
+
 class SimpleStorageBin(FoundationGridfinity):
 
     def __init__(self, obj):
         super(SimpleStorageBin, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject",
-                        "Bin", "base", "python gridfinity object")
+        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
 
         self.add_bin_properties(obj)
         self.add_custom_bin_properties(obj)
@@ -296,85 +592,255 @@ class SimpleStorageBin(FoundationGridfinity):
 
     def add_bin_properties(self, obj):
 
-        obj.addProperty("App::PropertyInteger","xGridUnits","Gridfinity","Length of the edges of the outline").xGridUnits=2
-        obj.addProperty("App::PropertyInteger","yGridUnits","Gridfinity","Height of the extrusion").yGridUnits=2
-        obj.addProperty("App::PropertyInteger","HeightUnits","Gridfinity","height of the bin in units, each unit is 7 mm").HeightUnits=6
-        obj.addProperty("App::PropertyBool","StackingLip","Gridfinity","Toggle the stacking lip on or off").StackingLip=True
-        obj.addProperty("App::PropertyBool","MagnetHoles","Gridfinity","Toggle the magnet holes on or off").MagnetHoles = True
-        obj.addProperty("App::PropertyBool","ScrewHoles","Gridfinity","Toggle the screw holes on or off").ScrewHoles = True
-        obj.addProperty("App::PropertyBool","Scoop","Gridfinity","Toggle the Scoop fillet on or off").Scoop = False
-        obj.addProperty("App::PropertyInteger","xDividers","Gridfinity","Select the Number of Dividers in the x direction").xDividers = 0
-        obj.addProperty("App::PropertyInteger","yDividers","Gridfinity","Select the number of Dividers in the y direction").yDividers = 0
-        obj.addProperty("App::PropertyEnumeration", "LabelShelfPlacement", "Gridfinity", "Choose the style of the label shelf")
+        obj.addProperty(
+            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+        ).xGridUnits = 2
+        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
+        obj.addProperty(
+            "App::PropertyInteger", "HeightUnits", "Gridfinity", "height of the bin in units, each unit is 7 mm"
+        ).HeightUnits = 6
+        obj.addProperty(
+            "App::PropertyBool", "StackingLip", "Gridfinity", "Toggle the stacking lip on or off"
+        ).StackingLip = True
+        obj.addProperty(
+            "App::PropertyBool", "MagnetHoles", "Gridfinity", "Toggle the magnet holes on or off"
+        ).MagnetHoles = True
+        obj.addProperty(
+            "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
+        ).ScrewHoles = True
+        obj.addProperty("App::PropertyBool", "Scoop", "Gridfinity", "Toggle the Scoop fillet on or off").Scoop = False
+        obj.addProperty(
+            "App::PropertyInteger", "xDividers", "Gridfinity", "Select the Number of Dividers in the x direction"
+        ).xDividers = 0
+        obj.addProperty(
+            "App::PropertyInteger", "yDividers", "Gridfinity", "Select the number of Dividers in the y direction"
+        ).yDividers = 0
+        obj.addProperty(
+            "App::PropertyEnumeration", "LabelShelfPlacement", "Gridfinity", "Choose the style of the label shelf"
+        )
         obj.LabelShelfPlacement = ["Center", "Full Width", "Left", "Right"]
-        obj.addProperty("App::PropertyEnumeration", "LabelShelfStyle", "Gridfinity", "Choose to turn the label shelf on or off")
-        obj.LabelShelfStyle = [ "Off", "Standard"]
+        obj.addProperty(
+            "App::PropertyEnumeration", "LabelShelfStyle", "Gridfinity", "Choose to turn the label shelf on or off"
+        )
+        obj.LabelShelfStyle = ["Off", "Standard"]
 
     def add_custom_bin_properties(self, obj):
-        obj.addProperty("App::PropertyLength","CustomHeight","GridfinityNonStandard","total height of the bin using the custom heignt instead of incraments of 7 mm").CustomHeight = 42
-        obj.addProperty("App::PropertyLength","SequentialBridgingLayerHeight","GridfinityNonStandard","Layer Height that you print in for optimal print results").SequentialBridgingLayerHeight = 0.2
-        obj.addProperty("App::PropertyBool","NonStandardHeight","GridfinityNonStandard","use a custom height if selected").NonStandardHeight=False
-        obj.addProperty("App::PropertyLength","MagnetHoleDiameter", "GridfinityNonStandard", "Diameter of Magnet Holes <br> <br> default = 6.5 mm").MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
-        obj.addProperty("App::PropertyLength","MagnetHoleDepth", "GridfinityNonStandard", "Depth of Magnet Holes <br> <br> default = 2.4 mm").MagnetHoleDepth = MAGNET_HOLE_DEPTH
-        obj.addProperty("App::PropertyLength","ScrewHoleDiameter", "GridfinityNonStandard", "Diameter of Screw Holes <br> <br> default = 3.0 mm").ScrewHoleDiameter = SCREW_HOLE_DIAMETER
-        obj.addProperty("App::PropertyLength","ScrewHoleDepth", "GridfinityNonStandard", "Depth of Screw Holes <br> <br> default = 6.0 mm").ScrewHoleDepth = SCREW_HOLE_DEPTH
-        obj.addProperty("App::PropertyLength","WallThickness", "GridfinityNonStandard", "Wall thickness of the bin <br> <br> default = 1.0 mm").WallThickness = 1.0
-        obj.addProperty("App::PropertyLength","InsideFilletRadius", "GridfinityNonStandard", "inside fillet at the bottom of the bin <br> <br> default = 1.85 mm").InsideFilletRadius = 1.85
-        obj.addProperty("App::PropertyLength","DividerThickness", "GridfinityNonStandard", "Thickness of the dividers, ideally an even multiple of layer width <br> <br> default = 1.2 mm").DividerThickness = 1.2
-        obj.addProperty("App::PropertyLength","LabelShelfWidth", "GridfinityNonStandard", "Thickness of the Label Shelf <br> <br> default = 1.2 mm").LabelShelfWidth = LABEL_SHELF_WIDTH
-        obj.addProperty("App::PropertyLength","LabelShelfLength", "GridfinityNonStandard", "Length of the Label Shelf <br> <br> default = 1.2 mm").LabelShelfLength = LABEL_SHELF_LENGTH
-        obj.addProperty("App::PropertyLength","ScoopRadius", "GridfinityNonStandard", "Radius of the Scoop <br> <br> default = 21 mm").ScoopRadius = SCOOP_RADIUS
-        obj.addProperty("App::PropertyLength","xDividerHeight", "GridfinityNonStandard", "Custom Height of x dividers <br> <br> default = 0 mm = full height").xDividerHeight = 0
-        obj.addProperty("App::PropertyLength","yDividerHeight", "GridfinityNonStandard", "Custom Height of y dividers <br> <br> default = 0 mm = full height").yDividerHeight = 0
+        obj.addProperty(
+            "App::PropertyLength",
+            "CustomHeight",
+            "GridfinityNonStandard",
+            "total height of the bin using the custom heignt instead of incraments of 7 mm",
+        ).CustomHeight = 42
+        obj.addProperty(
+            "App::PropertyLength",
+            "SequentialBridgingLayerHeight",
+            "GridfinityNonStandard",
+            "Layer Height that you print in for optimal print results",
+        ).SequentialBridgingLayerHeight = 0.2
+        obj.addProperty(
+            "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
+        ).NonStandardHeight = False
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDiameter",
+            "GridfinityNonStandard",
+            "Diameter of Magnet Holes <br> <br> default = 6.5 mm",
+        ).MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDepth",
+            "GridfinityNonStandard",
+            "Depth of Magnet Holes <br> <br> default = 2.4 mm",
+        ).MagnetHoleDepth = MAGNET_HOLE_DEPTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "ScrewHoleDiameter",
+            "GridfinityNonStandard",
+            "Diameter of Screw Holes <br> <br> default = 3.0 mm",
+        ).ScrewHoleDiameter = SCREW_HOLE_DIAMETER
+        obj.addProperty(
+            "App::PropertyLength",
+            "ScrewHoleDepth",
+            "GridfinityNonStandard",
+            "Depth of Screw Holes <br> <br> default = 6.0 mm",
+        ).ScrewHoleDepth = SCREW_HOLE_DEPTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "WallThickness",
+            "GridfinityNonStandard",
+            "Wall thickness of the bin <br> <br> default = 1.0 mm",
+        ).WallThickness = 1.0
+        obj.addProperty(
+            "App::PropertyLength",
+            "InsideFilletRadius",
+            "GridfinityNonStandard",
+            "inside fillet at the bottom of the bin <br> <br> default = 1.85 mm",
+        ).InsideFilletRadius = 1.85
+        obj.addProperty(
+            "App::PropertyLength",
+            "DividerThickness",
+            "GridfinityNonStandard",
+            "Thickness of the dividers, ideally an even multiple of layer width <br> <br> default = 1.2 mm",
+        ).DividerThickness = 1.2
+        obj.addProperty(
+            "App::PropertyLength",
+            "LabelShelfWidth",
+            "GridfinityNonStandard",
+            "Thickness of the Label Shelf <br> <br> default = 1.2 mm",
+        ).LabelShelfWidth = LABEL_SHELF_WIDTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "LabelShelfLength",
+            "GridfinityNonStandard",
+            "Length of the Label Shelf <br> <br> default = 1.2 mm",
+        ).LabelShelfLength = LABEL_SHELF_LENGTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "ScoopRadius",
+            "GridfinityNonStandard",
+            "Radius of the Scoop <br> <br> default = 21 mm",
+        ).ScoopRadius = SCOOP_RADIUS
+        obj.addProperty(
+            "App::PropertyLength",
+            "xDividerHeight",
+            "GridfinityNonStandard",
+            "Custom Height of x dividers <br> <br> default = 0 mm = full height",
+        ).xDividerHeight = 0
+        obj.addProperty(
+            "App::PropertyLength",
+            "yDividerHeight",
+            "GridfinityNonStandard",
+            "Custom Height of y dividers <br> <br> default = 0 mm = full height",
+        ).yDividerHeight = 0
 
     def add_reference_properties(self, obj):
-        obj.addProperty("App::PropertyLength","xTotalWidth","ReferenceDimensions","total width of bin in x direction", 1)
-        obj.addProperty("App::PropertyLength","yTotalWidth","ReferenceDimensions","total width of bin in y direction", 1)
-        obj.addProperty("App::PropertyLength","TotalHeight","ReferenceDimensions","total height of the bin", 1)
-        obj.addProperty("App::PropertyLength","BaseProfileHeight","ReferenceDimensions","Height of the Gridfinity Base Profile", 1)
-        obj.addProperty("App::PropertyLength","UsableHeight","ReferenceDimensions","Height of the bin minus the bottom unit, the amount of the bin that can be effectively used", 1)
-        obj.addProperty("App::PropertyLength","BinUnit", "ReferenceDimensions", "Width of a single bin unit",1).BinUnit = BIN_UNIT
+        obj.addProperty(
+            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+        )
+        obj.addProperty(
+            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+        )
+        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the bin", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileHeight",
+            "ReferenceDimensions",
+            "Height of the Gridfinity Base Profile",
+            1,
+        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "UsableHeight",
+            "ReferenceDimensions",
+            "Height of the bin minus the bottom unit, the amount of the bin that can be effectively used",
+            1,
+        )
+        obj.addProperty(
+            "App::PropertyLength", "BinUnit", "ReferenceDimensions", "Width of a single bin unit", 1
+        ).BinUnit = BIN_UNIT
 
     def add_expert_properties(self, obj):
-        obj.addProperty("App::PropertyLength","BaseProfileBottomChamfer", "zzExpertOnly", "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",1).BaseProfileBottomChamfer=BIN_BASE_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","BaseProfileVerticalSection", "zzExpertOnly", "Height of the vertical section in bin base profile",1).BaseProfileVerticalSection=BIN_BASE_VERTICAL_SECTION
-        obj.addProperty("App::PropertyLength","BaseProfileTopChamfer", "zzExpertOnly", "Height of the top chamfer in the bin base profile",1).BaseProfileTopChamfer=BIN_BASE_TOP_CHAMFER
-        obj.addProperty("App::PropertyLength","GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
-        obj.addProperty("App::PropertyLength","HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm",1).HeightUnitValue = HEIGHT_UNIT
-        obj.addProperty("App::PropertyLength","BinOuterRadius", "zzExpertOnly", "Outer radius of the bin",1).BinOuterRadius = BIN_OUTER_RADIUS
-        obj.addProperty("App::PropertyLength","BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section",1).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
-        obj.addProperty("App::PropertyLength","BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius",1).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileBottomChamfer",
+            "zzExpertOnly",
+            "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",
+            1,
+        ).BaseProfileBottomChamfer = BIN_BASE_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileVerticalSection",
+            "zzExpertOnly",
+            "Height of the vertical section in bin base profile",
+            1,
+        ).BaseProfileVerticalSection = BIN_BASE_VERTICAL_SECTION
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileTopChamfer",
+            "zzExpertOnly",
+            "Height of the top chamfer in the bin base profile",
+            1,
+        ).BaseProfileTopChamfer = BIN_BASE_TOP_CHAMFER
+        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+        ).HeightUnitValue = HEIGHT_UNIT
+        obj.addProperty(
+            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the bin", 1
+        ).BinOuterRadius = BIN_OUTER_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section", 1
+        ).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius", 1
+        ).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
 
-        obj.addProperty("App::PropertyLength","Tolerance", "zzExpertOnly", "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",1).Tolerance = TOLERANCE
-        obj.addProperty("App::PropertyLength","MagnetHoleDistanceFromEdge", "zzExpertOnly", "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",1).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
-        obj.addProperty("App::PropertyLength","StackingLipTopLedge", "zzExpertOnly", "Top Ledge of the stacking lip <br> <br> default = 0.4 mm",1).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
-        obj.addProperty("App::PropertyLength","StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip",1)
-        obj.addProperty("App::PropertyLength","StackingLipBottomChamfer", "zzExpertOnly", "Bottom Chamfer of the Stacking lip<br> <br> default = 0.7 mm",1).StackingLipBottomChamfer = STACKING_LIP_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","StackingLipVerticalSection", "zzExpertOnly", "vertical section of the Stacking lip<br> <br> default = 1.8 mm",1).StackingLipVerticalSection = STACKING_LIP_VERTICAL_SECTION
-        obj.addProperty("App::PropertyLength","LabelShelfVerticalThickness", "zzExpertOnly", "Vertical Thickness of the Label Shelf <br> <br> default = 2 mm").LabelShelfVerticalThickness = LABEL_SHELF_VERTICAL_THICKNESS
-
-
+        obj.addProperty(
+            "App::PropertyLength",
+            "Tolerance",
+            "zzExpertOnly",
+            "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",
+            1,
+        ).Tolerance = TOLERANCE
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDistanceFromEdge",
+            "zzExpertOnly",
+            "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",
+            1,
+        ).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipTopLedge",
+            "zzExpertOnly",
+            "Top Ledge of the stacking lip <br> <br> default = 0.4 mm",
+            1,
+        ).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
+        obj.addProperty(
+            "App::PropertyLength", "StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip", 1
+        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipBottomChamfer",
+            "zzExpertOnly",
+            "Bottom Chamfer of the Stacking lip<br> <br> default = 0.7 mm",
+            1,
+        ).StackingLipBottomChamfer = STACKING_LIP_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipVerticalSection",
+            "zzExpertOnly",
+            "vertical section of the Stacking lip<br> <br> default = 1.8 mm",
+            1,
+        ).StackingLipVerticalSection = STACKING_LIP_VERTICAL_SECTION
+        obj.addProperty(
+            "App::PropertyLength",
+            "LabelShelfVerticalThickness",
+            "zzExpertOnly",
+            "Vertical Thickness of the Label Shelf <br> <br> default = 2 mm",
+        ).LabelShelfVerticalThickness = LABEL_SHELF_VERTICAL_THICKNESS
 
     def generate_gridfinity_shape(self, obj):
 
         ## Parameter Calculations
 
-        obj.xTotalWidth = obj.xGridUnits*obj.GridSize-obj.Tolerance*2
-        obj.yTotalWidth = obj.yGridUnits*obj.GridSize-obj.Tolerance*2
-        obj.BaseProfileHeight = obj.BaseProfileBottomChamfer+obj.BaseProfileVerticalSection+obj.BaseProfileTopChamfer
+        obj.xTotalWidth = obj.xGridUnits * obj.GridSize - obj.Tolerance * 2
+        obj.yTotalWidth = obj.yGridUnits * obj.GridSize - obj.Tolerance * 2
+        obj.BaseProfileHeight = (
+            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+        )
         obj.StackingLipTopChamfer = obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
-        obj.BinUnit = obj.GridSize - TOLERANCE*2*unitmm
+        obj.BinUnit = obj.GridSize - TOLERANCE * 2 * unitmm
 
         if obj.NonStandardHeight:
             obj.TotalHeight = obj.CustomHeight
         else:
-            obj.TotalHeight = obj.HeightUnits*obj.HeightUnitValue
+            obj.TotalHeight = obj.HeightUnits * obj.HeightUnitValue
         obj.UsableHeight = obj.TotalHeight - obj.HeightUnitValue
 
         ## Error Checking
 
-
-        divmin = obj.HeightUnitValue + obj.InsideFilletRadius + 0.05*unitmm
+        divmin = obj.HeightUnitValue + obj.InsideFilletRadius + 0.05 * unitmm
         if obj.xDividerHeight < divmin and obj.xDividerHeight != 0:
             obj.xDividerHeight = divmin
             App.Console.PrintWarning("Divider Height must be equal to or greater than:  ")
@@ -390,8 +856,16 @@ class SimpleStorageBin(FoundationGridfinity):
         ## Bin Construction
         fuse_total = MakeBinBase(self, obj)
 
-        solid_center= RoundedRectangleExtrude(obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight+obj.BaseProfileHeight, obj.TotalHeight-obj.BaseProfileHeight, obj.BinOuterRadius)
-        solid_center.translate(App.Vector(obj.xTotalWidth/2-obj.BinUnit/2,obj.yTotalWidth/2-obj.BinUnit/2,0))
+        solid_center = RoundedRectangleExtrude(
+            obj.xTotalWidth,
+            obj.yTotalWidth,
+            -obj.TotalHeight + obj.BaseProfileHeight,
+            obj.TotalHeight - obj.BaseProfileHeight,
+            obj.BinOuterRadius,
+        )
+        solid_center.translate(
+            App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0)
+        )
         fuse_total = fuse_total.fuse(solid_center)
 
         compartements = MakeCompartements(self, obj)
@@ -400,7 +874,7 @@ class SimpleStorageBin(FoundationGridfinity):
 
         if obj.StackingLip:
             stacking_lip = MakeStackingLip(self, obj)
-            fuse_total = Part.Shape.fuse(stacking_lip,fuse_total)
+            fuse_total = Part.Shape.fuse(stacking_lip, fuse_total)
 
         if obj.ScrewHoles or obj.MagnetHoles:
             holes = MakeBottomHoles(self, obj)
@@ -416,7 +890,7 @@ class SimpleStorageBin(FoundationGridfinity):
 
         fuse_total = Part.Solid.removeSplitter(fuse_total)
 
-        #fuse_total.translate(App.Vector(obj.xTotalWidth/2-obj.BinUnit/2,obj.yTotalWidth/2-obj.BinUnit/2,0))
+        # fuse_total.translate(App.Vector(obj.xTotalWidth/2-obj.BinUnit/2,obj.yTotalWidth/2-obj.BinUnit/2,0))
 
         return fuse_total
 
@@ -432,8 +906,7 @@ class EcoBin(FoundationGridfinity):
     def __init__(self, obj):
         super(EcoBin, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject",
-                        "Bin", "base", "python gridfinity object")
+        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
 
         self.add_bin_properties(obj)
         self.add_custom_bin_properties(obj)
@@ -444,79 +917,223 @@ class EcoBin(FoundationGridfinity):
 
     def add_bin_properties(self, obj):
 
-        obj.addProperty("App::PropertyInteger","xGridUnits","Gridfinity","Length of the edges of the outline").xGridUnits=2
-        obj.addProperty("App::PropertyInteger","yGridUnits","Gridfinity","Height of the extrusion").yGridUnits=2
-        obj.addProperty("App::PropertyInteger","HeightUnits","Gridfinity","height of the bin in units, each unit is 7 mm").HeightUnits=6
-        obj.addProperty("App::PropertyBool","StackingLip","Gridfinity","Toggle the stacking lip on or off").StackingLip=True
-        obj.addProperty("App::PropertyBool","MagnetHoles","Gridfinity","Toggle the magnet holes on or off").MagnetHoles = False
+        obj.addProperty(
+            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+        ).xGridUnits = 2
+        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
+        obj.addProperty(
+            "App::PropertyInteger", "HeightUnits", "Gridfinity", "height of the bin in units, each unit is 7 mm"
+        ).HeightUnits = 6
+        obj.addProperty(
+            "App::PropertyBool", "StackingLip", "Gridfinity", "Toggle the stacking lip on or off"
+        ).StackingLip = True
+        obj.addProperty(
+            "App::PropertyBool", "MagnetHoles", "Gridfinity", "Toggle the magnet holes on or off"
+        ).MagnetHoles = False
 
-        obj.addProperty("App::PropertyInteger","xDividers","Gridfinity","Select the Number of Dividers in the x direction").xDividers = 0
-        obj.addProperty("App::PropertyInteger","yDividers","Gridfinity","Select the number of Dividers in the y direction").yDividers = 0
-        obj.addProperty("App::PropertyLength","BaseWallThickness","Gridfinity","The thickness of the bin at the base").BaseWallThickness = 0.8
+        obj.addProperty(
+            "App::PropertyInteger", "xDividers", "Gridfinity", "Select the Number of Dividers in the x direction"
+        ).xDividers = 0
+        obj.addProperty(
+            "App::PropertyInteger", "yDividers", "Gridfinity", "Select the number of Dividers in the y direction"
+        ).yDividers = 0
+        obj.addProperty(
+            "App::PropertyLength", "BaseWallThickness", "Gridfinity", "The thickness of the bin at the base"
+        ).BaseWallThickness = 0.8
 
     def add_custom_bin_properties(self, obj):
-        obj.addProperty("App::PropertyLength","CustomHeight","GridfinityNonStandard","total height of the bin using the custom heignt instead of incraments of 7 mm").CustomHeight = 42
-        obj.addProperty("App::PropertyLength","SequentialBridgingLayerHeight","GridfinityNonStandard","Layer Height that you print in for optimal print results").SequentialBridgingLayerHeight = 0.2
-        obj.addProperty("App::PropertyBool","NonStandardHeight","GridfinityNonStandard","use a custom height if selected").NonStandardHeight=False
-        obj.addProperty("App::PropertyLength","MagnetHoleDiameter", "GridfinityNonStandard", "Diameter of Magnet Holes <br> <br> default = 6.5 mm").MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
-        obj.addProperty("App::PropertyLength","MagnetHoleDepth", "GridfinityNonStandard", "Depth of Magnet Holes <br> <br> default = 2.4 mm").MagnetHoleDepth = MAGNET_HOLE_DEPTH
-        obj.addProperty("App::PropertyLength","WallThickness", "GridfinityNonStandard", "Wall thickness of the bin <br> <br> default = 0.8 mm").WallThickness = 0.8
-        obj.addProperty("App::PropertyLength","InsideFilletRadius", "GridfinityNonStandard", "inside fillet at the bottom of the bin <br> <br> default = 1.5 mm").InsideFilletRadius = 1.5
-        obj.addProperty("App::PropertyLength","DividerThickness", "GridfinityNonStandard", "Thickness of the dividers, ideally an even multiple of layer width <br> <br> default = 0.8 mm").DividerThickness = 0.8
-        obj.addProperty("App::PropertyLength","xDividerHeight", "GridfinityNonStandard", "Custom Height of x dividers <br> <br> default = 0 mm = full height").xDividerHeight = 0
-        obj.addProperty("App::PropertyLength","yDividerHeight", "GridfinityNonStandard", "Custom Height of y dividers <br> <br> default = 0 mm = full height").yDividerHeight = 0
+        obj.addProperty(
+            "App::PropertyLength",
+            "CustomHeight",
+            "GridfinityNonStandard",
+            "total height of the bin using the custom heignt instead of incraments of 7 mm",
+        ).CustomHeight = 42
+        obj.addProperty(
+            "App::PropertyLength",
+            "SequentialBridgingLayerHeight",
+            "GridfinityNonStandard",
+            "Layer Height that you print in for optimal print results",
+        ).SequentialBridgingLayerHeight = 0.2
+        obj.addProperty(
+            "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
+        ).NonStandardHeight = False
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDiameter",
+            "GridfinityNonStandard",
+            "Diameter of Magnet Holes <br> <br> default = 6.5 mm",
+        ).MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDepth",
+            "GridfinityNonStandard",
+            "Depth of Magnet Holes <br> <br> default = 2.4 mm",
+        ).MagnetHoleDepth = MAGNET_HOLE_DEPTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "WallThickness",
+            "GridfinityNonStandard",
+            "Wall thickness of the bin <br> <br> default = 0.8 mm",
+        ).WallThickness = 0.8
+        obj.addProperty(
+            "App::PropertyLength",
+            "InsideFilletRadius",
+            "GridfinityNonStandard",
+            "inside fillet at the bottom of the bin <br> <br> default = 1.5 mm",
+        ).InsideFilletRadius = 1.5
+        obj.addProperty(
+            "App::PropertyLength",
+            "DividerThickness",
+            "GridfinityNonStandard",
+            "Thickness of the dividers, ideally an even multiple of layer width <br> <br> default = 0.8 mm",
+        ).DividerThickness = 0.8
+        obj.addProperty(
+            "App::PropertyLength",
+            "xDividerHeight",
+            "GridfinityNonStandard",
+            "Custom Height of x dividers <br> <br> default = 0 mm = full height",
+        ).xDividerHeight = 0
+        obj.addProperty(
+            "App::PropertyLength",
+            "yDividerHeight",
+            "GridfinityNonStandard",
+            "Custom Height of y dividers <br> <br> default = 0 mm = full height",
+        ).yDividerHeight = 0
 
     def add_reference_properties(self, obj):
-        obj.addProperty("App::PropertyLength","xTotalWidth","ReferenceDimensions","total width of bin in x direction", 1)
-        obj.addProperty("App::PropertyLength","yTotalWidth","ReferenceDimensions","total width of bin in y direction", 1)
-        obj.addProperty("App::PropertyLength","TotalHeight","ReferenceDimensions","total height of the bin", 1)
-        obj.addProperty("App::PropertyLength","BaseProfileHeight","ReferenceDimensions","Height of the Gridfinity Base Profile", 1)
-        obj.addProperty("App::PropertyLength","BinUnit", "ReferenceDimensions", "Width of a single bin unit",1).BinUnit = BIN_UNIT
+        obj.addProperty(
+            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+        )
+        obj.addProperty(
+            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+        )
+        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the bin", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileHeight",
+            "ReferenceDimensions",
+            "Height of the Gridfinity Base Profile",
+            1,
+        )
+        obj.addProperty(
+            "App::PropertyLength", "BinUnit", "ReferenceDimensions", "Width of a single bin unit", 1
+        ).BinUnit = BIN_UNIT
 
     def add_expert_properties(self, obj):
-        obj.addProperty("App::PropertyLength","BaseProfileBottomChamfer", "zzExpertOnly", "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",1).BaseProfileBottomChamfer=BIN_BASE_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","BaseProfileVerticalSection", "zzExpertOnly", "Height of the vertical section in bin base profile",1).BaseProfileVerticalSection=BIN_BASE_VERTICAL_SECTION
-        obj.addProperty("App::PropertyLength","BaseProfileTopChamfer", "zzExpertOnly", "Height of the top chamfer in the bin base profile",1).BaseProfileTopChamfer=BIN_BASE_TOP_CHAMFER
-        obj.addProperty("App::PropertyLength","GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
-        obj.addProperty("App::PropertyLength","HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm",1).HeightUnitValue = HEIGHT_UNIT
-        obj.addProperty("App::PropertyLength","BinOuterRadius", "zzExpertOnly", "Outer radius of the bin",1).BinOuterRadius = BIN_OUTER_RADIUS
-        obj.addProperty("App::PropertyLength","BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section",1).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
-        obj.addProperty("App::PropertyLength","BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius",1).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileBottomChamfer",
+            "zzExpertOnly",
+            "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",
+            1,
+        ).BaseProfileBottomChamfer = BIN_BASE_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileVerticalSection",
+            "zzExpertOnly",
+            "Height of the vertical section in bin base profile",
+            1,
+        ).BaseProfileVerticalSection = BIN_BASE_VERTICAL_SECTION
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileTopChamfer",
+            "zzExpertOnly",
+            "Height of the top chamfer in the bin base profile",
+            1,
+        ).BaseProfileTopChamfer = BIN_BASE_TOP_CHAMFER
+        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+        ).HeightUnitValue = HEIGHT_UNIT
+        obj.addProperty(
+            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the bin", 1
+        ).BinOuterRadius = BIN_OUTER_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section", 1
+        ).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius", 1
+        ).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
 
-        obj.addProperty("App::PropertyLength","Tolerance", "zzExpertOnly", "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",1).Tolerance = TOLERANCE
-        obj.addProperty("App::PropertyLength","MagnetHoleDistanceFromEdge", "zzExpertOnly", "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",1).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
-        obj.addProperty("App::PropertyLength","StackingLipTopLedge", "zzExpertOnly", "Top Ledge of the stacking lip <br> <br> default = 0.4 mm",1).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
-        obj.addProperty("App::PropertyLength","StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip",1)
-        obj.addProperty("App::PropertyLength","StackingLipBottomChamfer", "zzExpertOnly", "Bottom Chamfer of the Stacking lip<br> <br> default = 0.7 mm",1).StackingLipBottomChamfer = STACKING_LIP_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","StackingLipVerticalSection", "zzExpertOnly", "vertical section of the Stacking lip<br> <br> default = 1.8 mm",1).StackingLipVerticalSection = STACKING_LIP_VERTICAL_SECTION
+        obj.addProperty(
+            "App::PropertyLength",
+            "Tolerance",
+            "zzExpertOnly",
+            "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",
+            1,
+        ).Tolerance = TOLERANCE
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDistanceFromEdge",
+            "zzExpertOnly",
+            "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",
+            1,
+        ).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipTopLedge",
+            "zzExpertOnly",
+            "Top Ledge of the stacking lip <br> <br> default = 0.4 mm",
+            1,
+        ).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
+        obj.addProperty(
+            "App::PropertyLength", "StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip", 1
+        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipBottomChamfer",
+            "zzExpertOnly",
+            "Bottom Chamfer of the Stacking lip<br> <br> default = 0.7 mm",
+            1,
+        ).StackingLipBottomChamfer = STACKING_LIP_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipVerticalSection",
+            "zzExpertOnly",
+            "vertical section of the Stacking lip<br> <br> default = 1.8 mm",
+            1,
+        ).StackingLipVerticalSection = STACKING_LIP_VERTICAL_SECTION
 
+        obj.addProperty(
+            "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
+        ).ScrewHoles = False
+        obj.setEditorMode("ScrewHoles", 2)
 
-        obj.addProperty("App::PropertyBool","ScrewHoles","Gridfinity","Toggle the screw holes on or off").ScrewHoles = False
-        obj.setEditorMode("ScrewHoles",2)
-
-        obj.addProperty("App::PropertyLength","ScrewHoleDiameter", "GridfinityNonStandard", "Diameter of Screw Holes <br> <br> default = 3.0 mm").ScrewHoleDiameter = SCREW_HOLE_DIAMETER
-        obj.setEditorMode("ScrewHoleDiameter",2)
-        obj.addProperty("App::PropertyLength","ScrewHoleDepth", "GridfinityNonStandard", "Depth of Screw Holes <br> <br> default = 6.0 mm").ScrewHoleDepth = SCREW_HOLE_DEPTH
-        obj.setEditorMode("ScrewHoleDepth",2)
+        obj.addProperty(
+            "App::PropertyLength",
+            "ScrewHoleDiameter",
+            "GridfinityNonStandard",
+            "Diameter of Screw Holes <br> <br> default = 3.0 mm",
+        ).ScrewHoleDiameter = SCREW_HOLE_DIAMETER
+        obj.setEditorMode("ScrewHoleDiameter", 2)
+        obj.addProperty(
+            "App::PropertyLength",
+            "ScrewHoleDepth",
+            "GridfinityNonStandard",
+            "Depth of Screw Holes <br> <br> default = 6.0 mm",
+        ).ScrewHoleDepth = SCREW_HOLE_DEPTH
+        obj.setEditorMode("ScrewHoleDepth", 2)
 
     def generate_gridfinity_shape(self, obj):
         ## Parameter Calculation
 
-        obj.xTotalWidth = obj.xGridUnits*obj.GridSize-obj.Tolerance*2
-        obj.yTotalWidth = obj.yGridUnits*obj.GridSize-obj.Tolerance*2
-        obj.BaseProfileHeight = obj.BaseProfileBottomChamfer+obj.BaseProfileVerticalSection+obj.BaseProfileTopChamfer
+        obj.xTotalWidth = obj.xGridUnits * obj.GridSize - obj.Tolerance * 2
+        obj.yTotalWidth = obj.yGridUnits * obj.GridSize - obj.Tolerance * 2
+        obj.BaseProfileHeight = (
+            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+        )
         obj.StackingLipTopChamfer = obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
-        obj.BinUnit = obj.GridSize - TOLERANCE*2*unitmm
+        obj.BinUnit = obj.GridSize - TOLERANCE * 2 * unitmm
 
         if obj.NonStandardHeight:
             obj.TotalHeight = obj.CustomHeight
         else:
-            obj.TotalHeight = obj.HeightUnits*obj.HeightUnitValue
+            obj.TotalHeight = obj.HeightUnits * obj.HeightUnitValue
 
         ## Error Checking
 
         # Divider Minimum Height
-        divmin = obj.HeightUnitValue + obj.InsideFilletRadius + 0.05*unitmm
+        divmin = obj.HeightUnitValue + obj.InsideFilletRadius + 0.05 * unitmm
         if obj.xDividerHeight < divmin and obj.xDividerHeight != 0:
             obj.xDividerHeight = divmin
             App.Console.PrintWarning("Divider Height must be equal to or greater than:  ")
@@ -529,16 +1146,24 @@ class EcoBin(FoundationGridfinity):
             App.Console.PrintWarning(divmin)
             App.Console.PrintWarning("\n")
 
-        if obj.InsideFilletRadius > (1.6*unitmm):
-            obj.InsideFilletRadius = 1.6*unitmm
+        if obj.InsideFilletRadius > (1.6 * unitmm):
+            obj.InsideFilletRadius = 1.6 * unitmm
             App.Console.PrintWarning("Inside Fillet Radius must be equal to or less than:  1.6 mm\n")
 
         ## Bin Construction
 
         fuse_total = MakeBinBase(self, obj)
 
-        solid_center= RoundedRectangleExtrude(obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight+obj.BaseProfileHeight, obj.TotalHeight-obj.BaseProfileHeight, obj.BinOuterRadius)
-        solid_center.translate(App.Vector(obj.xTotalWidth/2-obj.BinUnit/2,obj.yTotalWidth/2-obj.BinUnit/2,0))
+        solid_center = RoundedRectangleExtrude(
+            obj.xTotalWidth,
+            obj.yTotalWidth,
+            -obj.TotalHeight + obj.BaseProfileHeight,
+            obj.TotalHeight - obj.BaseProfileHeight,
+            obj.BinOuterRadius,
+        )
+        solid_center.translate(
+            App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0)
+        )
         fuse_total = fuse_total.fuse(solid_center)
 
         compartements = MakeEcoBinCut(self, obj)
@@ -547,7 +1172,7 @@ class EcoBin(FoundationGridfinity):
 
         if obj.StackingLip:
             stacking_lip = MakeStackingLip(self, obj)
-            fuse_total = Part.Shape.fuse(stacking_lip,fuse_total)
+            fuse_total = Part.Shape.fuse(stacking_lip, fuse_total)
 
         if obj.MagnetHoles:
             holes = MakeBottomHoles(self, obj)
@@ -569,8 +1194,7 @@ class PartsBin(FoundationGridfinity):
     def __init__(self, obj):
         super(PartsBin, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject",
-                        "Bin", "base", "python gridfinity object")
+        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
 
         self.add_bin_properties(obj)
         self.add_custom_bin_properties(obj)
@@ -581,85 +1205,256 @@ class PartsBin(FoundationGridfinity):
 
     def add_bin_properties(self, obj):
 
-        obj.addProperty("App::PropertyInteger","xGridUnits","Gridfinity","Length of the edges of the outline").xGridUnits=2
-        obj.addProperty("App::PropertyInteger","yGridUnits","Gridfinity","Height of the extrusion").yGridUnits=2
-        obj.addProperty("App::PropertyInteger","HeightUnits","Gridfinity","height of the bin in units, each unit is 7 mm").HeightUnits=6
-        obj.addProperty("App::PropertyBool","StackingLip","Gridfinity","Toggle the stacking lip on or off").StackingLip=True
-        obj.addProperty("App::PropertyBool","MagnetHoles","Gridfinity","Toggle the magnet holes on or off").MagnetHoles = True
-        obj.addProperty("App::PropertyBool","ScrewHoles","Gridfinity","Toggle the screw holes on or off").ScrewHoles = True
-        obj.addProperty("App::PropertyBool","Scoop","Gridfinity","Toggle the Scoop fillet on or off").Scoop = True
-        obj.addProperty("App::PropertyInteger","xDividers","Gridfinity","Select the Number of Dividers in the x direction").xDividers = 0
-        obj.addProperty("App::PropertyInteger","yDividers","Gridfinity","Select the number of Dividers in the y direction").yDividers = 1
-        obj.addProperty("App::PropertyEnumeration", "LabelShelfPlacement", "Gridfinity", "Choose the style of the label shelf")
+        obj.addProperty(
+            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+        ).xGridUnits = 2
+        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
+        obj.addProperty(
+            "App::PropertyInteger", "HeightUnits", "Gridfinity", "height of the bin in units, each unit is 7 mm"
+        ).HeightUnits = 6
+        obj.addProperty(
+            "App::PropertyBool", "StackingLip", "Gridfinity", "Toggle the stacking lip on or off"
+        ).StackingLip = True
+        obj.addProperty(
+            "App::PropertyBool", "MagnetHoles", "Gridfinity", "Toggle the magnet holes on or off"
+        ).MagnetHoles = True
+        obj.addProperty(
+            "App::PropertyBool", "ScrewHoles", "Gridfinity", "Toggle the screw holes on or off"
+        ).ScrewHoles = True
+        obj.addProperty("App::PropertyBool", "Scoop", "Gridfinity", "Toggle the Scoop fillet on or off").Scoop = True
+        obj.addProperty(
+            "App::PropertyInteger", "xDividers", "Gridfinity", "Select the Number of Dividers in the x direction"
+        ).xDividers = 0
+        obj.addProperty(
+            "App::PropertyInteger", "yDividers", "Gridfinity", "Select the number of Dividers in the y direction"
+        ).yDividers = 1
+        obj.addProperty(
+            "App::PropertyEnumeration", "LabelShelfPlacement", "Gridfinity", "Choose the style of the label shelf"
+        )
         obj.LabelShelfPlacement = ["Center", "Full Width", "Left", "Right"]
-        obj.addProperty("App::PropertyEnumeration", "LabelShelfStyle", "Gridfinity", "Choose to turn the label shelf on or off")
+        obj.addProperty(
+            "App::PropertyEnumeration", "LabelShelfStyle", "Gridfinity", "Choose to turn the label shelf on or off"
+        )
         obj.LabelShelfStyle = ["Standard", "Off"]
 
     def add_custom_bin_properties(self, obj):
-        obj.addProperty("App::PropertyLength","CustomHeight","GridfinityNonStandard","total height of the bin using the custom heignt instead of incraments of 7 mm").CustomHeight = 42
-        obj.addProperty("App::PropertyLength","SequentialBridgingLayerHeight","GridfinityNonStandard","Layer Height that you print in for optimal print results").SequentialBridgingLayerHeight = 0.2
-        obj.addProperty("App::PropertyBool","NonStandardHeight","GridfinityNonStandard","use a custom height if selected").NonStandardHeight=False
-        obj.addProperty("App::PropertyLength","MagnetHoleDiameter", "GridfinityNonStandard", "Diameter of Magnet Holes <br> <br> default = 6.5 mm").MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
-        obj.addProperty("App::PropertyLength","MagnetHoleDepth", "GridfinityNonStandard", "Depth of Magnet Holes <br> <br> default = 2.4 mm").MagnetHoleDepth = MAGNET_HOLE_DEPTH
-        obj.addProperty("App::PropertyLength","ScrewHoleDiameter", "GridfinityNonStandard", "Diameter of Screw Holes <br> <br> default = 3.0 mm").ScrewHoleDiameter = SCREW_HOLE_DIAMETER
-        obj.addProperty("App::PropertyLength","ScrewHoleDepth", "GridfinityNonStandard", "Depth of Screw Holes <br> <br> default = 6.0 mm").ScrewHoleDepth = SCREW_HOLE_DEPTH
-        obj.addProperty("App::PropertyLength","WallThickness", "GridfinityNonStandard", "Wall thickness of the bin <br> <br> default = 1.0 mm").WallThickness = 1.0
-        obj.addProperty("App::PropertyLength","InsideFilletRadius", "GridfinityNonStandard", "inside fillet at the bottom of the bin <br> <br> default = 1.85 mm").InsideFilletRadius = 1.85
-        obj.addProperty("App::PropertyLength","DividerThickness", "GridfinityNonStandard", "Thickness of the dividers, ideally an even multiple of layer width <br> <br> default = 1.2 mm").DividerThickness = 1.2
-        obj.addProperty("App::PropertyLength","LabelShelfWidth", "GridfinityNonStandard", "Thickness of the Label Shelf <br> <br> default = 1.2 mm").LabelShelfWidth = LABEL_SHELF_WIDTH
-        obj.addProperty("App::PropertyLength","LabelShelfLength", "GridfinityNonStandard", "Length of the Label Shelf <br> <br> default = 1.2 mm").LabelShelfLength = LABEL_SHELF_LENGTH
-        obj.addProperty("App::PropertyLength","ScoopRadius", "GridfinityNonStandard", "Radius of the Scoop <br> <br> default = 21 mm").ScoopRadius = SCOOP_RADIUS
-        obj.addProperty("App::PropertyLength","xDividerHeight", "GridfinityNonStandard", "Custom Height of x dividers <br> <br> default = 0 mm = full height").xDividerHeight = 0
-        obj.addProperty("App::PropertyLength","yDividerHeight", "GridfinityNonStandard", "Custom Height of y dividers <br> <br> default = 0 mm = full height").yDividerHeight = 0
+        obj.addProperty(
+            "App::PropertyLength",
+            "CustomHeight",
+            "GridfinityNonStandard",
+            "total height of the bin using the custom heignt instead of incraments of 7 mm",
+        ).CustomHeight = 42
+        obj.addProperty(
+            "App::PropertyLength",
+            "SequentialBridgingLayerHeight",
+            "GridfinityNonStandard",
+            "Layer Height that you print in for optimal print results",
+        ).SequentialBridgingLayerHeight = 0.2
+        obj.addProperty(
+            "App::PropertyBool", "NonStandardHeight", "GridfinityNonStandard", "use a custom height if selected"
+        ).NonStandardHeight = False
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDiameter",
+            "GridfinityNonStandard",
+            "Diameter of Magnet Holes <br> <br> default = 6.5 mm",
+        ).MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDepth",
+            "GridfinityNonStandard",
+            "Depth of Magnet Holes <br> <br> default = 2.4 mm",
+        ).MagnetHoleDepth = MAGNET_HOLE_DEPTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "ScrewHoleDiameter",
+            "GridfinityNonStandard",
+            "Diameter of Screw Holes <br> <br> default = 3.0 mm",
+        ).ScrewHoleDiameter = SCREW_HOLE_DIAMETER
+        obj.addProperty(
+            "App::PropertyLength",
+            "ScrewHoleDepth",
+            "GridfinityNonStandard",
+            "Depth of Screw Holes <br> <br> default = 6.0 mm",
+        ).ScrewHoleDepth = SCREW_HOLE_DEPTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "WallThickness",
+            "GridfinityNonStandard",
+            "Wall thickness of the bin <br> <br> default = 1.0 mm",
+        ).WallThickness = 1.0
+        obj.addProperty(
+            "App::PropertyLength",
+            "InsideFilletRadius",
+            "GridfinityNonStandard",
+            "inside fillet at the bottom of the bin <br> <br> default = 1.85 mm",
+        ).InsideFilletRadius = 1.85
+        obj.addProperty(
+            "App::PropertyLength",
+            "DividerThickness",
+            "GridfinityNonStandard",
+            "Thickness of the dividers, ideally an even multiple of layer width <br> <br> default = 1.2 mm",
+        ).DividerThickness = 1.2
+        obj.addProperty(
+            "App::PropertyLength",
+            "LabelShelfWidth",
+            "GridfinityNonStandard",
+            "Thickness of the Label Shelf <br> <br> default = 1.2 mm",
+        ).LabelShelfWidth = LABEL_SHELF_WIDTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "LabelShelfLength",
+            "GridfinityNonStandard",
+            "Length of the Label Shelf <br> <br> default = 1.2 mm",
+        ).LabelShelfLength = LABEL_SHELF_LENGTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "ScoopRadius",
+            "GridfinityNonStandard",
+            "Radius of the Scoop <br> <br> default = 21 mm",
+        ).ScoopRadius = SCOOP_RADIUS
+        obj.addProperty(
+            "App::PropertyLength",
+            "xDividerHeight",
+            "GridfinityNonStandard",
+            "Custom Height of x dividers <br> <br> default = 0 mm = full height",
+        ).xDividerHeight = 0
+        obj.addProperty(
+            "App::PropertyLength",
+            "yDividerHeight",
+            "GridfinityNonStandard",
+            "Custom Height of y dividers <br> <br> default = 0 mm = full height",
+        ).yDividerHeight = 0
 
     def add_reference_properties(self, obj):
-        obj.addProperty("App::PropertyLength","xTotalWidth","ReferenceDimensions","total width of bin in x direction", 1)
-        obj.addProperty("App::PropertyLength","yTotalWidth","ReferenceDimensions","total width of bin in y direction", 1)
-        obj.addProperty("App::PropertyLength","TotalHeight","ReferenceDimensions","total height of the bin", 1)
-        obj.addProperty("App::PropertyLength","BaseProfileHeight","ReferenceDimensions","Height of the Gridfinity Base Profile", 1)
-        obj.addProperty("App::PropertyLength","UsableHeight","ReferenceDimensions","Height of the bin minus the bottom unit, the amount of the bin that can be effectively used", 1)
-        obj.addProperty("App::PropertyLength","BinUnit", "ReferenceDimensions", "Width of a single bin unit",1).BinUnit = BIN_UNIT
+        obj.addProperty(
+            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+        )
+        obj.addProperty(
+            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+        )
+        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the bin", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileHeight",
+            "ReferenceDimensions",
+            "Height of the Gridfinity Base Profile",
+            1,
+        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "UsableHeight",
+            "ReferenceDimensions",
+            "Height of the bin minus the bottom unit, the amount of the bin that can be effectively used",
+            1,
+        )
+        obj.addProperty(
+            "App::PropertyLength", "BinUnit", "ReferenceDimensions", "Width of a single bin unit", 1
+        ).BinUnit = BIN_UNIT
 
     def add_expert_properties(self, obj):
-        obj.addProperty("App::PropertyLength","BaseProfileBottomChamfer", "zzExpertOnly", "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",1).BaseProfileBottomChamfer=BIN_BASE_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","BaseProfileVerticalSection", "zzExpertOnly", "Height of the vertical section in bin base profile",1).BaseProfileVerticalSection=BIN_BASE_VERTICAL_SECTION
-        obj.addProperty("App::PropertyLength","BaseProfileTopChamfer", "zzExpertOnly", "Height of the top chamfer in the bin base profile",1).BaseProfileTopChamfer=BIN_BASE_TOP_CHAMFER
-        obj.addProperty("App::PropertyLength","GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
-        obj.addProperty("App::PropertyLength","HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm",1).HeightUnitValue = HEIGHT_UNIT
-        obj.addProperty("App::PropertyLength","BinOuterRadius", "zzExpertOnly", "Outer radius of the bin",1).BinOuterRadius = BIN_OUTER_RADIUS
-        obj.addProperty("App::PropertyLength","BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section",1).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
-        obj.addProperty("App::PropertyLength","BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius",1).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileBottomChamfer",
+            "zzExpertOnly",
+            "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",
+            1,
+        ).BaseProfileBottomChamfer = BIN_BASE_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileVerticalSection",
+            "zzExpertOnly",
+            "Height of the vertical section in bin base profile",
+            1,
+        ).BaseProfileVerticalSection = BIN_BASE_VERTICAL_SECTION
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileTopChamfer",
+            "zzExpertOnly",
+            "Height of the top chamfer in the bin base profile",
+            1,
+        ).BaseProfileTopChamfer = BIN_BASE_TOP_CHAMFER
+        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+        ).HeightUnitValue = HEIGHT_UNIT
+        obj.addProperty(
+            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the bin", 1
+        ).BinOuterRadius = BIN_OUTER_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BinVerticalRadius", "zzExpertOnly", "Radius of the base profile Vertical section", 1
+        ).BinVerticalRadius = BIN_BASE_VERTICAL_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of bin corner radius", 1
+        ).BinBottomRadius = BIN_BASE_BOTTOM_RADIUS
 
-        obj.addProperty("App::PropertyLength","Tolerance", "zzExpertOnly", "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",1).Tolerance = TOLERANCE
-        obj.addProperty("App::PropertyLength","MagnetHoleDistanceFromEdge", "zzExpertOnly", "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",1).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
-        obj.addProperty("App::PropertyLength","StackingLipTopLedge", "zzExpertOnly", "Top Ledge of the stacking lip <br> <br> default = 0.4 mm",1).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
-        obj.addProperty("App::PropertyLength","StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip",1)
-        obj.addProperty("App::PropertyLength","StackingLipBottomChamfer", "zzExpertOnly", "Bottom Chamfer of the Stacking lip<br> <br> default = 0.7 mm",1).StackingLipBottomChamfer = STACKING_LIP_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","StackingLipVerticalSection", "zzExpertOnly", "vertical section of the Stacking lip<br> <br> default = 1.8 mm",1).StackingLipVerticalSection = STACKING_LIP_VERTICAL_SECTION
-        obj.addProperty("App::PropertyLength","LabelShelfVerticalThickness", "zzExpertOnly", "Vertical Thickness of the Label Shelf <br> <br> default = 2 mm").LabelShelfVerticalThickness = LABEL_SHELF_VERTICAL_THICKNESS
-
-
+        obj.addProperty(
+            "App::PropertyLength",
+            "Tolerance",
+            "zzExpertOnly",
+            "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",
+            1,
+        ).Tolerance = TOLERANCE
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDistanceFromEdge",
+            "zzExpertOnly",
+            "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",
+            1,
+        ).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipTopLedge",
+            "zzExpertOnly",
+            "Top Ledge of the stacking lip <br> <br> default = 0.4 mm",
+            1,
+        ).StackingLipTopLedge = STACKING_LIP_TOP_LEDGE
+        obj.addProperty(
+            "App::PropertyLength", "StackingLipTopChamfer", "zzExpertOnly", "Top Chamfer of the Stacking lip", 1
+        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipBottomChamfer",
+            "zzExpertOnly",
+            "Bottom Chamfer of the Stacking lip<br> <br> default = 0.7 mm",
+            1,
+        ).StackingLipBottomChamfer = STACKING_LIP_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "StackingLipVerticalSection",
+            "zzExpertOnly",
+            "vertical section of the Stacking lip<br> <br> default = 1.8 mm",
+            1,
+        ).StackingLipVerticalSection = STACKING_LIP_VERTICAL_SECTION
+        obj.addProperty(
+            "App::PropertyLength",
+            "LabelShelfVerticalThickness",
+            "zzExpertOnly",
+            "Vertical Thickness of the Label Shelf <br> <br> default = 2 mm",
+        ).LabelShelfVerticalThickness = LABEL_SHELF_VERTICAL_THICKNESS
 
     def generate_gridfinity_shape(self, obj):
 
         ## Calculated Properties
 
-        obj.xTotalWidth = obj.xGridUnits*obj.GridSize-obj.Tolerance*2
-        obj.yTotalWidth = obj.yGridUnits*obj.GridSize-obj.Tolerance*2
-        obj.BaseProfileHeight = obj.BaseProfileBottomChamfer+obj.BaseProfileVerticalSection+obj.BaseProfileTopChamfer
+        obj.xTotalWidth = obj.xGridUnits * obj.GridSize - obj.Tolerance * 2
+        obj.yTotalWidth = obj.yGridUnits * obj.GridSize - obj.Tolerance * 2
+        obj.BaseProfileHeight = (
+            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+        )
         obj.StackingLipTopChamfer = obj.BaseProfileTopChamfer - obj.Tolerance - obj.StackingLipTopLedge
-        obj.BinUnit = obj.GridSize - TOLERANCE*2*unitmm
+        obj.BinUnit = obj.GridSize - TOLERANCE * 2 * unitmm
 
         if obj.NonStandardHeight:
             obj.TotalHeight = obj.CustomHeight
         else:
-            obj.TotalHeight = obj.HeightUnits*obj.HeightUnitValue
+            obj.TotalHeight = obj.HeightUnits * obj.HeightUnitValue
         obj.UsableHeight = obj.TotalHeight - obj.HeightUnitValue
 
         ## Error Checking
 
         # Divider Minimum Height
-        divmin = obj.HeightUnitValue + obj.InsideFilletRadius + 0.05*unitmm
+        divmin = obj.HeightUnitValue + obj.InsideFilletRadius + 0.05 * unitmm
         if obj.xDividerHeight < divmin and obj.xDividerHeight != 0:
             obj.xDividerHeight = divmin
             App.Console.PrintWarning("Divider Height must be equal to or greater than:  ")
@@ -672,7 +1467,12 @@ class PartsBin(FoundationGridfinity):
             App.Console.PrintWarning(divmin)
             App.Console.PrintWarning("\n")
 
-        if obj.xDividerHeight < obj.TotalHeight and obj.LabelShelfStyle != "Off" and obj.xDividerHeight != 0 and obj.xDividers != 0:
+        if (
+            obj.xDividerHeight < obj.TotalHeight
+            and obj.LabelShelfStyle != "Off"
+            and obj.xDividerHeight != 0
+            and obj.xDividers != 0
+        ):
             obj.LabelShelfStyle = "Off"
             App.Console.PrintWarning("Label Shelf turned off for less than full height x dividers")
 
@@ -680,8 +1480,16 @@ class PartsBin(FoundationGridfinity):
 
         fuse_total = MakeBinBase(self, obj)
 
-        solid_center= RoundedRectangleExtrude(obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight+obj.BaseProfileHeight, obj.TotalHeight-obj.BaseProfileHeight, obj.BinOuterRadius)
-        solid_center.translate(App.Vector(obj.xTotalWidth/2-obj.BinUnit/2,obj.yTotalWidth/2-obj.BinUnit/2,0))
+        solid_center = RoundedRectangleExtrude(
+            obj.xTotalWidth,
+            obj.yTotalWidth,
+            -obj.TotalHeight + obj.BaseProfileHeight,
+            obj.TotalHeight - obj.BaseProfileHeight,
+            obj.BinOuterRadius,
+        )
+        solid_center.translate(
+            App.Vector(obj.xTotalWidth / 2 - obj.BinUnit / 2, obj.yTotalWidth / 2 - obj.BinUnit / 2, 0)
+        )
         fuse_total = fuse_total.fuse(solid_center)
 
         compartements = MakeCompartements(self, obj)
@@ -690,7 +1498,7 @@ class PartsBin(FoundationGridfinity):
 
         if obj.StackingLip:
             stacking_lip = MakeStackingLip(self, obj)
-            fuse_total = Part.Shape.fuse(stacking_lip,fuse_total)
+            fuse_total = Part.Shape.fuse(stacking_lip, fuse_total)
 
         if obj.ScrewHoles or obj.MagnetHoles:
             holes = MakeBottomHoles(self, obj)
@@ -708,66 +1516,129 @@ class PartsBin(FoundationGridfinity):
 
         return fuse_total
 
-
     def __getstate__(self):
         return None
 
     def __setstate__(self, state):
         return None
 
-class Baseplate(FoundationGridfinity):
 
+class Baseplate(FoundationGridfinity):
 
     def __init__(self, obj):
         super(Baseplate, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject",
-                        "Bin", "base", "python gridfinity object")
+        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
 
         self.add_bin_properties(obj)
         self.add_reference_properties(obj)
         self.add_expert_properties(obj)
 
-
         obj.Proxy = self
 
     def add_bin_properties(self, obj):
 
-        obj.addProperty("App::PropertyInteger","xGridUnits","Gridfinity","Length of the edges of the outline").xGridUnits=2
-        obj.addProperty("App::PropertyInteger","yGridUnits","Gridfinity","Height of the extrusion").yGridUnits=2
+        obj.addProperty(
+            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+        ).xGridUnits = 2
+        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
 
     def add_reference_properties(self, obj):
-        obj.addProperty("App::PropertyLength","xTotalWidth","ReferenceDimensions","total width of bin in x direction", 1)
-        obj.addProperty("App::PropertyLength","yTotalWidth","ReferenceDimensions","total width of bin in y direction", 1)
-        obj.addProperty("App::PropertyLength","TotalHeight","ReferenceDimensions","total height of the bin", 1)
-        obj.addProperty("App::PropertyLength","BaseProfileHeight","ReferenceDimensions","Height of the Gridfinity Base Profile", 1)
+        obj.addProperty(
+            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+        )
+        obj.addProperty(
+            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+        )
+        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the bin", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileHeight",
+            "ReferenceDimensions",
+            "Height of the Gridfinity Base Profile",
+            1,
+        )
 
     def add_expert_properties(self, obj):
-        obj.addProperty("App::PropertyLength","BaseProfileBottomChamfer", "zzExpertOnly", "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",1).BaseProfileBottomChamfer=BASEPLATE_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","BaseProfileVerticalSection", "zzExpertOnly", "Height of the vertical section in bin base profile",1).BaseProfileVerticalSection=BASEPLATE_VERTICAL_SECTION
-        obj.addProperty("App::PropertyLength","BaseProfileTopChamfer", "zzExpertOnly", "Height of the top chamfer in the bin base profile",1).BaseProfileTopChamfer=BASEPLATE_TOP_CHAMFER
-        obj.addProperty("App::PropertyLength","BaseplateProfileTotalHeight", "zzExpertOnly", "Height of the bin base profile",1)
-        obj.addProperty("App::PropertyLength","GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
-        obj.addProperty("App::PropertyLength","HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm",1).HeightUnitValue = 7
-        obj.addProperty("App::PropertyLength","BinOuterRadius", "zzExpertOnly", "Outer radius of the baseplate",1).BinOuterRadius = BASEPLATE_OUTER_RADIUS
-        obj.addProperty("App::PropertyLength","BinVerticalRadius", "zzExpertOnly", "Radius of the baseplate profile Vertical section",1).BinVerticalRadius = BASEPLATE_VERTICAL_RADIUS
-        obj.addProperty("App::PropertyLength","BinBottomRadius", "zzExpertOnly", "bottom of baseplate corner radius",1).BinBottomRadius = BASEPLATE_BOTTOM_RADIUS
-        obj.addProperty("App::PropertyLength","BaseplateTopLedgeWidth", "zzExpertOnly", "Top ledge of baseplate",1).BaseplateTopLedgeWidth = BASEPLATE_TOP_LEDGE_WIDTH
-        obj.addProperty("App::PropertyLength","BinUnit", "zzExpertOnly", "Width of a single bin unit",2).BinUnit = BIN_UNIT
-        obj.addProperty("App::PropertyLength","Tolerance", "zzExpertOnly", "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",1).Tolerance = TOLERANCE
-        obj.addProperty("App::PropertyLength","MagnetHoleDistanceFromEdge", "zzExpertOnly", "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",1).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileBottomChamfer",
+            "zzExpertOnly",
+            "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",
+            1,
+        ).BaseProfileBottomChamfer = BASEPLATE_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileVerticalSection",
+            "zzExpertOnly",
+            "Height of the vertical section in bin base profile",
+            1,
+        ).BaseProfileVerticalSection = BASEPLATE_VERTICAL_SECTION
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileTopChamfer",
+            "zzExpertOnly",
+            "Height of the top chamfer in the bin base profile",
+            1,
+        ).BaseProfileTopChamfer = BASEPLATE_TOP_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength", "BaseplateProfileTotalHeight", "zzExpertOnly", "Height of the bin base profile", 1
+        )
+        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+        ).HeightUnitValue = 7
+        obj.addProperty(
+            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the baseplate", 1
+        ).BinOuterRadius = BASEPLATE_OUTER_RADIUS
+        obj.addProperty(
+            "App::PropertyLength",
+            "BinVerticalRadius",
+            "zzExpertOnly",
+            "Radius of the baseplate profile Vertical section",
+            1,
+        ).BinVerticalRadius = BASEPLATE_VERTICAL_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of baseplate corner radius", 1
+        ).BinBottomRadius = BASEPLATE_BOTTOM_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BaseplateTopLedgeWidth", "zzExpertOnly", "Top ledge of baseplate", 1
+        ).BaseplateTopLedgeWidth = BASEPLATE_TOP_LEDGE_WIDTH
+        obj.addProperty("App::PropertyLength", "BinUnit", "zzExpertOnly", "Width of a single bin unit", 2).BinUnit = (
+            BIN_UNIT
+        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "Tolerance",
+            "zzExpertOnly",
+            "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",
+            1,
+        ).Tolerance = TOLERANCE
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDistanceFromEdge",
+            "zzExpertOnly",
+            "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",
+            1,
+        ).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
 
     def generate_gridfinity_shape(self, obj):
 
-        obj.xTotalWidth = obj.xGridUnits*obj.GridSize
-        obj.yTotalWidth = obj.yGridUnits*obj.GridSize
-        obj.BaseProfileHeight = obj.BaseProfileBottomChamfer+obj.BaseProfileVerticalSection+obj.BaseProfileTopChamfer
+        obj.xTotalWidth = obj.xGridUnits * obj.GridSize
+        obj.yTotalWidth = obj.yGridUnits * obj.GridSize
+        obj.BaseProfileHeight = (
+            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+        )
         obj.TotalHeight = obj.BaseProfileHeight
-        obj.BinUnit = obj.GridSize - obj.BaseplateTopLedgeWidth *2
+        obj.BinUnit = obj.GridSize - obj.BaseplateTopLedgeWidth * 2
 
         fuse_total = MakeBinBase(self, obj)
-        solid_center= RoundedRectangleExtrude(obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight, obj.TotalHeight, obj.BinOuterRadius)
-        solid_center.translate(App.Vector(obj.xTotalWidth/2-obj.GridSize/2,obj.yTotalWidth/2-obj.GridSize/2,0))
+        solid_center = RoundedRectangleExtrude(
+            obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight, obj.TotalHeight, obj.BinOuterRadius
+        )
+        solid_center.translate(
+            App.Vector(obj.xTotalWidth / 2 - obj.GridSize / 2, obj.yTotalWidth / 2 - obj.GridSize / 2, 0)
+        )
         fuse_total = Part.Shape.cut(solid_center, fuse_total)
 
         return fuse_total
@@ -778,13 +1649,13 @@ class Baseplate(FoundationGridfinity):
     def __setstate__(self, state):
         return None
 
+
 class MagnetBaseplate(FoundationGridfinity):
 
     def __init__(self, obj):
         super(MagnetBaseplate, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject",
-                        "Bin", "base", "python gridfinity object")
+        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
 
         self.add_bin_properties(obj)
         self.add_reference_properties(obj)
@@ -792,70 +1663,169 @@ class MagnetBaseplate(FoundationGridfinity):
         self.add_custom_baseplate_properties(obj)
         self.add_hidded_properties(obj)
 
-
         obj.Proxy = self
 
     def add_bin_properties(self, obj):
 
-        obj.addProperty("App::PropertyInteger","xGridUnits","Gridfinity","Length of the edges of the outline").xGridUnits=2
-        obj.addProperty("App::PropertyInteger","yGridUnits","Gridfinity","Height of the extrusion").yGridUnits=2
-        obj.addProperty("App::PropertyBool","MagnetHoles","Gridfinity","MagnetHoles").MagnetHoles = True
-
+        obj.addProperty(
+            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+        ).xGridUnits = 2
+        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
+        obj.addProperty("App::PropertyBool", "MagnetHoles", "Gridfinity", "MagnetHoles").MagnetHoles = True
 
     def add_reference_properties(self, obj):
-        obj.addProperty("App::PropertyLength","xTotalWidth","ReferenceDimensions","total width of bin in x direction", 1)
-        obj.addProperty("App::PropertyLength","yTotalWidth","ReferenceDimensions","total width of bin in y direction", 1)
-        obj.addProperty("App::PropertyLength","TotalHeight","ReferenceDimensions","total height of the baseplate", 1)
-        obj.addProperty("App::PropertyLength","BaseProfileHeight","ReferenceDimensions","Height of the Gridfinity Base Profile", 1)
-
+        obj.addProperty(
+            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+        )
+        obj.addProperty(
+            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+        )
+        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the baseplate", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileHeight",
+            "ReferenceDimensions",
+            "Height of the Gridfinity Base Profile",
+            1,
+        )
 
     def add_custom_baseplate_properties(self, obj):
-        obj.addProperty("App::PropertyLength","SmallFillet","NonStandard","Small fillet on iside of baseplate <br> <br> default = 1 mm").SmallFillet = BASEPLATE_SMALL_FILLET
-        obj.addProperty("App::PropertyLength","MagnetHoleDiameter", "NonStandard", "Diameter of Magnet Holes <br> <br> default = 6.5 mm").MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
-        obj.addProperty("App::PropertyLength","MagnetHoleDepth", "NonStandard", "Depth of Magnet Holes <br> <br> default = 2.4 mm").MagnetHoleDepth = MAGNET_HOLE_DEPTH
-        obj.addProperty("App::PropertyLength","MagnetEdgeThickness", "NonStandard", "Thickness of edge holding magnets in place <br> <br> default = 1.2 mm").MagnetEdgeThickness = MAGNET_EDGE_THICKNESS
-        obj.addProperty("App::PropertyLength","MagnetBase", "NonStandard", "Thickness of base under the magnets <br> <br> default = 0.4 mm").MagnetBase = MAGNET_BASE
-        obj.addProperty("App::PropertyLength","MagnetBaseHole", "NonStandard", "Diameter of the hole at the bottom of the magnet cutout <br> <br> default = 3 mm").MagnetBaseHole = MAGNET_BASE_HOLE
-        obj.addProperty("App::PropertyLength","MagnetChamfer", "NonStandard", "Chamfer at top of magnet hole <br> <br> default = 0.4 mm").MagnetChamfer = MAGNET_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "SmallFillet",
+            "NonStandard",
+            "Small fillet on iside of baseplate <br> <br> default = 1 mm",
+        ).SmallFillet = BASEPLATE_SMALL_FILLET
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDiameter",
+            "NonStandard",
+            "Diameter of Magnet Holes <br> <br> default = 6.5 mm",
+        ).MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
+        obj.addProperty(
+            "App::PropertyLength", "MagnetHoleDepth", "NonStandard", "Depth of Magnet Holes <br> <br> default = 2.4 mm"
+        ).MagnetHoleDepth = MAGNET_HOLE_DEPTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetEdgeThickness",
+            "NonStandard",
+            "Thickness of edge holding magnets in place <br> <br> default = 1.2 mm",
+        ).MagnetEdgeThickness = MAGNET_EDGE_THICKNESS
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetBase",
+            "NonStandard",
+            "Thickness of base under the magnets <br> <br> default = 0.4 mm",
+        ).MagnetBase = MAGNET_BASE
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetBaseHole",
+            "NonStandard",
+            "Diameter of the hole at the bottom of the magnet cutout <br> <br> default = 3 mm",
+        ).MagnetBaseHole = MAGNET_BASE_HOLE
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetChamfer",
+            "NonStandard",
+            "Chamfer at top of magnet hole <br> <br> default = 0.4 mm",
+        ).MagnetChamfer = MAGNET_CHAMFER
 
     def add_expert_properties(self, obj):
-        obj.addProperty("App::PropertyLength","BaseProfileBottomChamfer", "zzExpertOnly", "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",1).BaseProfileBottomChamfer=BASEPLATE_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","BaseProfileVerticalSection", "zzExpertOnly", "Height of the vertical section in bin base profile",1).BaseProfileVerticalSection=BASEPLATE_VERTICAL_SECTION
-        obj.addProperty("App::PropertyLength","BaseProfileTopChamfer", "zzExpertOnly", "Height of the top chamfer in the bin base profile",1).BaseProfileTopChamfer=BASEPLATE_TOP_CHAMFER
-        obj.addProperty("App::PropertyLength","BaseplateProfileTotalHeight", "zzExpertOnly", "Height of the bin base profile",1)
-        obj.addProperty("App::PropertyLength","GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
-        obj.addProperty("App::PropertyLength","HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm",1).HeightUnitValue = 7
-        obj.addProperty("App::PropertyLength","BinOuterRadius", "zzExpertOnly", "Outer radius of the baseplate",1).BinOuterRadius = BASEPLATE_OUTER_RADIUS
-        obj.addProperty("App::PropertyLength","BinVerticalRadius", "zzExpertOnly", "Radius of the baseplate profile Vertical section",1).BinVerticalRadius = BASEPLATE_VERTICAL_RADIUS
-        obj.addProperty("App::PropertyLength","BinBottomRadius", "zzExpertOnly", "bottom of baseplate corner radius",1).BinBottomRadius = BASEPLATE_BOTTOM_RADIUS
-        obj.addProperty("App::PropertyLength","BaseplateTopLedgeWidth", "zzExpertOnly", "Top ledge of baseplate",1).BaseplateTopLedgeWidth = BASEPLATE_TOP_LEDGE_WIDTH
-        obj.addProperty("App::PropertyLength","BinUnit", "zzExpertOnly", "Width of a single bin unit",2).BinUnit = BIN_UNIT
-        obj.addProperty("App::PropertyLength","Tolerance", "zzExpertOnly", "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",1).Tolerance = TOLERANCE
-        obj.addProperty("App::PropertyLength","MagnetHoleDistanceFromEdge", "zzExpertOnly", "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",1).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileBottomChamfer",
+            "zzExpertOnly",
+            "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",
+            1,
+        ).BaseProfileBottomChamfer = BASEPLATE_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileVerticalSection",
+            "zzExpertOnly",
+            "Height of the vertical section in bin base profile",
+            1,
+        ).BaseProfileVerticalSection = BASEPLATE_VERTICAL_SECTION
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileTopChamfer",
+            "zzExpertOnly",
+            "Height of the top chamfer in the bin base profile",
+            1,
+        ).BaseProfileTopChamfer = BASEPLATE_TOP_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength", "BaseplateProfileTotalHeight", "zzExpertOnly", "Height of the bin base profile", 1
+        )
+        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+        ).HeightUnitValue = 7
+        obj.addProperty(
+            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the baseplate", 1
+        ).BinOuterRadius = BASEPLATE_OUTER_RADIUS
+        obj.addProperty(
+            "App::PropertyLength",
+            "BinVerticalRadius",
+            "zzExpertOnly",
+            "Radius of the baseplate profile Vertical section",
+            1,
+        ).BinVerticalRadius = BASEPLATE_VERTICAL_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of baseplate corner radius", 1
+        ).BinBottomRadius = BASEPLATE_BOTTOM_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BaseplateTopLedgeWidth", "zzExpertOnly", "Top ledge of baseplate", 1
+        ).BaseplateTopLedgeWidth = BASEPLATE_TOP_LEDGE_WIDTH
+        obj.addProperty("App::PropertyLength", "BinUnit", "zzExpertOnly", "Width of a single bin unit", 2).BinUnit = (
+            BIN_UNIT
+        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "Tolerance",
+            "zzExpertOnly",
+            "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",
+            1,
+        ).Tolerance = TOLERANCE
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDistanceFromEdge",
+            "zzExpertOnly",
+            "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",
+            1,
+        ).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
 
-    def add_hidded_properties(self,obj):
-        obj.addProperty("App::PropertyLength","BaseThickness", "NonStandard", "Thickness of base under the normal baseplate  profile <br> <br> default = 6.4 mm").BaseThickness = BASE_THICKNESS
-        obj.setEditorMode("BaseThickness",2)
+    def add_hidded_properties(self, obj):
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseThickness",
+            "NonStandard",
+            "Thickness of base under the normal baseplate  profile <br> <br> default = 6.4 mm",
+        ).BaseThickness = BASE_THICKNESS
+        obj.setEditorMode("BaseThickness", 2)
 
     def generate_gridfinity_shape(self, obj):
 
-        obj.xTotalWidth = obj.xGridUnits*obj.GridSize
-        obj.yTotalWidth = obj.yGridUnits*obj.GridSize
+        obj.xTotalWidth = obj.xGridUnits * obj.GridSize
+        obj.yTotalWidth = obj.yGridUnits * obj.GridSize
 
+        # Bottom of Bin placement, used for ability to reuse previous features.
+        obj.BaseProfileHeight = (
+            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+        )
 
-        #Bottom of Bin placement, used for ability to reuse previous features.
-        obj.BaseProfileHeight = obj.BaseProfileBottomChamfer+obj.BaseProfileVerticalSection+obj.BaseProfileTopChamfer
-
-        #actaully the total height of the baseplate
+        # actaully the total height of the baseplate
         obj.TotalHeight = obj.BaseProfileHeight + obj.MagnetHoleDepth + obj.MagnetBase
 
-        obj.BinUnit = obj.GridSize - obj.BaseplateTopLedgeWidth *2
+        obj.BinUnit = obj.GridSize - obj.BaseplateTopLedgeWidth * 2
 
         fuse_total = MakeBinBase(self, obj)
-        fuse_total.translate(App.Vector(0,0,obj.TotalHeight - obj.BaseProfileHeight))
+        fuse_total.translate(App.Vector(0, 0, obj.TotalHeight - obj.BaseProfileHeight))
 
-        solid_center= RoundedRectangleExtrude(obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight, obj.TotalHeight, obj.BinOuterRadius)
-        solid_center.translate(App.Vector(obj.xTotalWidth/2-obj.GridSize/2,obj.yTotalWidth/2-obj.GridSize/2,0))
+        solid_center = RoundedRectangleExtrude(
+            obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight, obj.TotalHeight, obj.BinOuterRadius
+        )
+        solid_center.translate(
+            App.Vector(obj.xTotalWidth / 2 - obj.GridSize / 2, obj.yTotalWidth / 2 - obj.GridSize / 2, 0)
+        )
         fuse_total = Part.Shape.cut(solid_center, fuse_total)
 
         cutout = MakeBaseplateCenterCut(self, obj)
@@ -872,81 +1842,188 @@ class MagnetBaseplate(FoundationGridfinity):
     def __setstate__(self, state):
         return None
 
+
 class ScrewTogetherBaseplate(FoundationGridfinity):
 
     def __init__(self, obj):
         super(ScrewTogetherBaseplate, self).__init__(obj)
 
-        obj.addProperty("App::PropertyPythonObject",
-                        "Bin", "base", "python gridfinity object")
+        obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
 
         self.add_bin_properties(obj)
         self.add_reference_properties(obj)
         self.add_expert_properties(obj)
         self.add_custom_baseplate_properties(obj)
 
-
         obj.Proxy = self
 
     def add_bin_properties(self, obj):
 
-        obj.addProperty("App::PropertyInteger","xGridUnits","Gridfinity","Length of the edges of the outline").xGridUnits=2
-        obj.addProperty("App::PropertyInteger","yGridUnits","Gridfinity","Height of the extrusion").yGridUnits=2
-
+        obj.addProperty(
+            "App::PropertyInteger", "xGridUnits", "Gridfinity", "Length of the edges of the outline"
+        ).xGridUnits = 2
+        obj.addProperty("App::PropertyInteger", "yGridUnits", "Gridfinity", "Height of the extrusion").yGridUnits = 2
 
     def add_reference_properties(self, obj):
-        obj.addProperty("App::PropertyLength","xTotalWidth","ReferenceDimensions","total width of bin in x direction", 1)
-        obj.addProperty("App::PropertyLength","yTotalWidth","ReferenceDimensions","total width of bin in y direction", 1)
-        obj.addProperty("App::PropertyLength","TotalHeight","ReferenceDimensions","total height of the baseplate", 1)
-        obj.addProperty("App::PropertyLength","BaseProfileHeight","ReferenceDimensions","Height of the Gridfinity Base Profile", 1)
-
+        obj.addProperty(
+            "App::PropertyLength", "xTotalWidth", "ReferenceDimensions", "total width of bin in x direction", 1
+        )
+        obj.addProperty(
+            "App::PropertyLength", "yTotalWidth", "ReferenceDimensions", "total width of bin in y direction", 1
+        )
+        obj.addProperty("App::PropertyLength", "TotalHeight", "ReferenceDimensions", "total height of the baseplate", 1)
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileHeight",
+            "ReferenceDimensions",
+            "Height of the Gridfinity Base Profile",
+            1,
+        )
 
     def add_custom_baseplate_properties(self, obj):
-        obj.addProperty("App::PropertyLength","SmallFillet","NonStandard","Small fillet on iside of baseplate <br> <br> default = 1 mm").SmallFillet = BASEPLATE_SMALL_FILLET
-        obj.addProperty("App::PropertyLength","MagnetHoleDiameter", "NonStandard", "Diameter of Magnet Holes <br> <br> default = 6.5 mm").MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
-        obj.addProperty("App::PropertyLength","MagnetHoleDepth", "NonStandard", "Depth of Magnet Holes <br> <br> default = 2.4 mm").MagnetHoleDepth = MAGNET_HOLE_DEPTH
-        obj.addProperty("App::PropertyLength","MagnetEdgeThickness", "NonStandard", "Thickness of edge holding magnets in place <br> <br> default = 1.2 mm").MagnetEdgeThickness = MAGNET_EDGE_THICKNESS
-        obj.addProperty("App::PropertyLength","BaseThickness", "NonStandard", "Thickness of base under the normal baseplate  profile <br> <br> default = 6.4 mm").BaseThickness = BASE_THICKNESS
-        obj.addProperty("App::PropertyLength","MagnetBaseHole", "NonStandard", "Diameter of the hole at the bottom of the magnet cutout <br> <br> default = 3 mm").MagnetBaseHole = MAGNET_BASE_HOLE
-        obj.addProperty("App::PropertyLength","MagnetChamfer", "NonStandard", "Chamfer at top of magnet hole <br> <br> default = 0.4 mm").MagnetChamfer = MAGNET_CHAMFER
-        obj.addProperty("App::PropertyLength","MagnetBottomChamfer", "NonStandard", "Chamfer at bottom of magnet hole <br> <br> default = 2 mm").MagnetBottomChamfer = MAGNET_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","ScrewHoleDiameter", "NonStandard", "Diameter of screw holes inside magnet holes <br> <br> default = 3 mm").ScrewHoleDiameter =  SCREW_HOLE_DIAMETER
-        obj.addProperty("App::PropertyLength","ConnectionHoleDiameter", "NonStandard", "Holes on the sides to connect multiple baseplates together <br> <br> default = 3.2 mm").ConnectionHoleDiameter = CONNECTION_HOLE_DIAMETER
+        obj.addProperty(
+            "App::PropertyLength",
+            "SmallFillet",
+            "NonStandard",
+            "Small fillet on iside of baseplate <br> <br> default = 1 mm",
+        ).SmallFillet = BASEPLATE_SMALL_FILLET
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDiameter",
+            "NonStandard",
+            "Diameter of Magnet Holes <br> <br> default = 6.5 mm",
+        ).MagnetHoleDiameter = MAGNET_HOLE_DIAMETER
+        obj.addProperty(
+            "App::PropertyLength", "MagnetHoleDepth", "NonStandard", "Depth of Magnet Holes <br> <br> default = 2.4 mm"
+        ).MagnetHoleDepth = MAGNET_HOLE_DEPTH
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetEdgeThickness",
+            "NonStandard",
+            "Thickness of edge holding magnets in place <br> <br> default = 1.2 mm",
+        ).MagnetEdgeThickness = MAGNET_EDGE_THICKNESS
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseThickness",
+            "NonStandard",
+            "Thickness of base under the normal baseplate  profile <br> <br> default = 6.4 mm",
+        ).BaseThickness = BASE_THICKNESS
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetBaseHole",
+            "NonStandard",
+            "Diameter of the hole at the bottom of the magnet cutout <br> <br> default = 3 mm",
+        ).MagnetBaseHole = MAGNET_BASE_HOLE
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetChamfer",
+            "NonStandard",
+            "Chamfer at top of magnet hole <br> <br> default = 0.4 mm",
+        ).MagnetChamfer = MAGNET_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetBottomChamfer",
+            "NonStandard",
+            "Chamfer at bottom of magnet hole <br> <br> default = 2 mm",
+        ).MagnetBottomChamfer = MAGNET_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "ScrewHoleDiameter",
+            "NonStandard",
+            "Diameter of screw holes inside magnet holes <br> <br> default = 3 mm",
+        ).ScrewHoleDiameter = SCREW_HOLE_DIAMETER
+        obj.addProperty(
+            "App::PropertyLength",
+            "ConnectionHoleDiameter",
+            "NonStandard",
+            "Holes on the sides to connect multiple baseplates together <br> <br> default = 3.2 mm",
+        ).ConnectionHoleDiameter = CONNECTION_HOLE_DIAMETER
 
     def add_expert_properties(self, obj):
-        obj.addProperty("App::PropertyLength","BaseProfileBottomChamfer", "zzExpertOnly", "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",1).BaseProfileBottomChamfer=BASEPLATE_BOTTOM_CHAMFER
-        obj.addProperty("App::PropertyLength","BaseProfileVerticalSection", "zzExpertOnly", "Height of the vertical section in bin base profile",1).BaseProfileVerticalSection=BASEPLATE_VERTICAL_SECTION
-        obj.addProperty("App::PropertyLength","BaseProfileTopChamfer", "zzExpertOnly", "Height of the top chamfer in the bin base profile",1).BaseProfileTopChamfer=BASEPLATE_TOP_CHAMFER
-        obj.addProperty("App::PropertyLength","BaseplateProfileTotalHeight", "zzExpertOnly", "Height of the bin base profile",1)
-        obj.addProperty("App::PropertyLength","GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
-        obj.addProperty("App::PropertyLength","HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm",1).HeightUnitValue = 7
-        obj.addProperty("App::PropertyLength","BinOuterRadius", "zzExpertOnly", "Outer radius of the baseplate",1).BinOuterRadius = BASEPLATE_OUTER_RADIUS
-        obj.addProperty("App::PropertyLength","BinVerticalRadius", "zzExpertOnly", "Radius of the baseplate profile Vertical section",1).BinVerticalRadius = BASEPLATE_VERTICAL_RADIUS
-        obj.addProperty("App::PropertyLength","BinBottomRadius", "zzExpertOnly", "bottom of baseplate corner radius",1).BinBottomRadius = BASEPLATE_BOTTOM_RADIUS
-        obj.addProperty("App::PropertyLength","BaseplateTopLedgeWidth", "zzExpertOnly", "Top ledge of baseplate",1).BaseplateTopLedgeWidth = BASEPLATE_TOP_LEDGE_WIDTH
-        obj.addProperty("App::PropertyLength","BinUnit", "zzExpertOnly", "Width of a single bin unit",2).BinUnit = BIN_UNIT
-        obj.addProperty("App::PropertyLength","Tolerance", "zzExpertOnly", "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm").Tolerance = TOLERANCE
-        obj.addProperty("App::PropertyLength","MagnetHoleDistanceFromEdge", "zzExpertOnly", "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm").MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
-
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileBottomChamfer",
+            "zzExpertOnly",
+            "height of chamfer in bottom of bin                                                                                                         base profile <br> <br> default = 0.8 mm",
+            1,
+        ).BaseProfileBottomChamfer = BASEPLATE_BOTTOM_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileVerticalSection",
+            "zzExpertOnly",
+            "Height of the vertical section in bin base profile",
+            1,
+        ).BaseProfileVerticalSection = BASEPLATE_VERTICAL_SECTION
+        obj.addProperty(
+            "App::PropertyLength",
+            "BaseProfileTopChamfer",
+            "zzExpertOnly",
+            "Height of the top chamfer in the bin base profile",
+            1,
+        ).BaseProfileTopChamfer = BASEPLATE_TOP_CHAMFER
+        obj.addProperty(
+            "App::PropertyLength", "BaseplateProfileTotalHeight", "zzExpertOnly", "Height of the bin base profile", 1
+        )
+        obj.addProperty("App::PropertyLength", "GridSize", "zzExpertOnly", "Size of the Grid").GridSize = GRID_SIZE
+        obj.addProperty(
+            "App::PropertyLength", "HeightUnitValue", "zzExpertOnly", "height per unit, default is 7mm", 1
+        ).HeightUnitValue = 7
+        obj.addProperty(
+            "App::PropertyLength", "BinOuterRadius", "zzExpertOnly", "Outer radius of the baseplate", 1
+        ).BinOuterRadius = BASEPLATE_OUTER_RADIUS
+        obj.addProperty(
+            "App::PropertyLength",
+            "BinVerticalRadius",
+            "zzExpertOnly",
+            "Radius of the baseplate profile Vertical section",
+            1,
+        ).BinVerticalRadius = BASEPLATE_VERTICAL_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BinBottomRadius", "zzExpertOnly", "bottom of baseplate corner radius", 1
+        ).BinBottomRadius = BASEPLATE_BOTTOM_RADIUS
+        obj.addProperty(
+            "App::PropertyLength", "BaseplateTopLedgeWidth", "zzExpertOnly", "Top ledge of baseplate", 1
+        ).BaseplateTopLedgeWidth = BASEPLATE_TOP_LEDGE_WIDTH
+        obj.addProperty("App::PropertyLength", "BinUnit", "zzExpertOnly", "Width of a single bin unit", 2).BinUnit = (
+            BIN_UNIT
+        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "Tolerance",
+            "zzExpertOnly",
+            "The tolerance on each side of a bin between before the edge of the grid <br> <br> default = 0.25 mm",
+        ).Tolerance = TOLERANCE
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleDistanceFromEdge",
+            "zzExpertOnly",
+            "Distance of the magnet holes from bin edge <br> <br> default = 8.0 mm",
+        ).MagnetHoleDistanceFromEdge = MAGNET_HOLE_DISTANCE_FROM_EDGE
 
     def generate_gridfinity_shape(self, obj):
 
-        obj.xTotalWidth = obj.xGridUnits*obj.GridSize
-        obj.yTotalWidth = obj.yGridUnits*obj.GridSize
+        obj.xTotalWidth = obj.xGridUnits * obj.GridSize
+        obj.yTotalWidth = obj.yGridUnits * obj.GridSize
 
-        #Bottom of Bin placement, used for ability to reuse previous features.
-        obj.BaseProfileHeight = obj.BaseProfileBottomChamfer+obj.BaseProfileVerticalSection+obj.BaseProfileTopChamfer
+        # Bottom of Bin placement, used for ability to reuse previous features.
+        obj.BaseProfileHeight = (
+            obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+        )
 
-        #actaully the total height of the baseplate
+        # actaully the total height of the baseplate
         obj.TotalHeight = obj.BaseProfileHeight + obj.BaseThickness
 
-        obj.BinUnit = obj.GridSize - obj.BaseplateTopLedgeWidth *2
+        obj.BinUnit = obj.GridSize - obj.BaseplateTopLedgeWidth * 2
 
         fuse_total = MakeBinBase(self, obj)
-        fuse_total.translate(App.Vector(0,0,obj.TotalHeight - obj.BaseProfileHeight))
+        fuse_total.translate(App.Vector(0, 0, obj.TotalHeight - obj.BaseProfileHeight))
 
-        solid_center= RoundedRectangleExtrude(obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight, obj.TotalHeight, obj.BinOuterRadius)
-        solid_center.translate(App.Vector(obj.xTotalWidth/2-obj.GridSize/2,obj.yTotalWidth/2-obj.GridSize/2,0))
+        solid_center = RoundedRectangleExtrude(
+            obj.xTotalWidth, obj.yTotalWidth, -obj.TotalHeight, obj.TotalHeight, obj.BinOuterRadius
+        )
+        solid_center.translate(
+            App.Vector(obj.xTotalWidth / 2 - obj.GridSize / 2, obj.yTotalWidth / 2 - obj.GridSize / 2, 0)
+        )
         fuse_total = Part.Shape.cut(solid_center, fuse_total)
 
         cutout = MakeBaseplateCenterCut(self, obj)
@@ -968,4 +2045,3 @@ class ScrewTogetherBaseplate(FoundationGridfinity):
 
     def __setstate__(self, state):
         return None
-

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -70,6 +70,8 @@ __all__ = [
     "EcoBin",
 ]
 
+HOLE_SHAPES = ["Round", "Hex"]
+
 
 def fcvec(x):
     if len(x) == 2:
@@ -192,7 +194,7 @@ class BinBlank(FoundationGridfinity):
             "GridfinityNonStandard",
             "Shape of magnet holes. <br> <br> Hex meant to be press fit. <br> Round meant to be glued",
         )
-        obj.MagnetHolesShape = ["Hex", "Round"]
+        obj.MagnetHolesShape = HOLE_SHAPES
         obj.addProperty(
             "App::PropertyLength",
             "MagnetHoleDiameter",
@@ -419,7 +421,7 @@ class BinBase(FoundationGridfinity):
             "GridfinityNonStandard",
             "Shape of magnet holes. <br> <br> Hex meant to be press fit. <br> Round meant to be glued",
         )
-        obj.MagnetHolesShape = ["Hex", "Round"]
+        obj.MagnetHolesShape = HOLE_SHAPES
         obj.addProperty(
             "App::PropertyLength",
             "MagnetHoleDiameter",
@@ -662,7 +664,7 @@ class SimpleStorageBin(FoundationGridfinity):
             "GridfinityNonStandard",
             "Shape of magnet holes. <br> <br> Hex meant to be press fit. <br> Round meant to be glued",
         )
-        obj.MagnetHolesShape = ["Hex", "Round"]
+        obj.MagnetHolesShape = HOLE_SHAPES
         obj.addProperty(
             "App::PropertyLength",
             "MagnetHoleDiameter",
@@ -986,7 +988,7 @@ class EcoBin(FoundationGridfinity):
             "GridfinityNonStandard",
             "Shape of magnet holes. <br> <br> Hex meant to be press fit. <br> Round meant to be glued",
         )
-        obj.MagnetHolesShape = ["Hex", "Round"]
+        obj.MagnetHolesShape = HOLE_SHAPES
         obj.addProperty(
             "App::PropertyLength",
             "MagnetHoleDiameter",
@@ -1289,7 +1291,7 @@ class PartsBin(FoundationGridfinity):
             "GridfinityNonStandard",
             "Shape of magnet holes. <br> <br> Hex meant to be press fit. <br> Round meant to be glued",
         )
-        obj.MagnetHolesShape = ["Hex", "Round"]
+        obj.MagnetHolesShape = HOLE_SHAPES
         obj.addProperty(
             "App::PropertyLength",
             "MagnetHoleDiameter",


### PR DESCRIPTION
Stumbled upon a speed optimization when working on adding hex holes to bases.  
Base creation included large fuse operations inside a loop.   Fuses are slow, so moved the fuse out of the loop, and use a copy operation in the loop.  This provides a noticeable speed increase when working with bases.
