### PR TITLE
Cleanup

### DIFF
--- a/freecad/gridfinity_workbench/baseplate_feature_construction.py
+++ b/freecad/gridfinity_workbench/baseplate_feature_construction.py
@@ -40,7 +40,10 @@ def _baseplate_magnet_hole_hex(
     p = fc.ActiveDocument.addObject("Part::RegularPolygon")
     p.Polygon = n_sides
     p.Circumradius = radius
-    p.Placement = fc.Placement(fc.Vector(x_hole_pos, -y_hole_pos), rot,)
+    p.Placement = fc.Placement(
+        fc.Vector(x_hole_pos, -y_hole_pos),
+        rot,
+    )
     p.recompute()
     f = Part.Face(Part.Wire(p.Shape.Edges))
     c2 = f.extrude(fc.Vector(0, 0, -obj.MagnetHoleDepth))
@@ -100,10 +103,7 @@ def _baseplate_magnet_hole_round(
         for pos in utils.corners(x_hole_pos, y_hole_pos, -obj.MagnetChamfer)
     ]
 
-    ch = [
-        Part.makeLoft([t, b], solid=True)
-        for t, b in zip(ct, cb)
-    ]
+    ch = [Part.makeLoft([t, b], solid=True) for t, b in zip(ct, cb)]
 
     return utils.multi_fuse(c + ch)
 
@@ -329,10 +329,7 @@ class BaseplateScrewBottomChamfer(utils.Feature):
             for pos in utils.corners(x_hole_pos, y_hole_pos, cb_z)
         ]
 
-        ch = [
-            Part.makeLoft([t, b], solid=True)
-            for t, b in zip(ct, cb)
-        ]
+        ch = [Part.makeLoft([t, b], solid=True) for t, b in zip(ct, cb)]
 
         xtranslate = zeromm
         ytranslate = zeromm

--- a/freecad/gridfinity_workbench/baseplate_feature_construction.py
+++ b/freecad/gridfinity_workbench/baseplate_feature_construction.py
@@ -31,10 +31,7 @@ def _baseplate_magnet_hole_hex(
     p = fc.ActiveDocument.addObject("Part::RegularPolygon")
     p.Polygon = n_sides
     p.Circumradius = radius
-    p.Placement = fc.Placement(
-        fc.Vector(-x_hole_pos, -y_hole_pos, 0),
-        rot,
-    )
+    p.Placement = fc.Placement(fc.Vector(-x_hole_pos, -y_hole_pos), rot)
     p.recompute()
     f = Part.Face(Part.Wire(p.Shape.Edges))
     c1 = f.extrude(fc.Vector(0, 0, -obj.MagnetHoleDepth))
@@ -43,10 +40,7 @@ def _baseplate_magnet_hole_hex(
     p = fc.ActiveDocument.addObject("Part::RegularPolygon")
     p.Polygon = n_sides
     p.Circumradius = radius
-    p.Placement = fc.Placement(
-        fc.Vector(x_hole_pos, -y_hole_pos, 0),
-        rot,
-    )
+    p.Placement = fc.Placement(fc.Vector(x_hole_pos, -y_hole_pos), rot,)
     p.recompute()
     f = Part.Face(Part.Wire(p.Shape.Edges))
     c2 = f.extrude(fc.Vector(0, 0, -obj.MagnetHoleDepth))
@@ -55,10 +49,7 @@ def _baseplate_magnet_hole_hex(
     p = fc.ActiveDocument.addObject("Part::RegularPolygon")
     p.Polygon = n_sides
     p.Circumradius = radius
-    p.Placement = fc.Placement(
-        fc.Vector(-x_hole_pos, y_hole_pos, 0),
-        rot,
-    )
+    p.Placement = fc.Placement(fc.Vector(-x_hole_pos, y_hole_pos), rot)
     p.recompute()
     f = Part.Face(Part.Wire(p.Shape.Edges))
     c3 = f.extrude(fc.Vector(0, 0, -obj.MagnetHoleDepth))
@@ -67,10 +58,7 @@ def _baseplate_magnet_hole_hex(
     p = fc.ActiveDocument.addObject("Part::RegularPolygon")
     p.Polygon = n_sides
     p.Circumradius = radius
-    p.Placement = fc.Placement(
-        fc.Vector(x_hole_pos, y_hole_pos, 0),
-        rot,
-    )
+    p.Placement = fc.Placement(fc.Vector(x_hole_pos, y_hole_pos), rot)
     p.recompute()
     f = Part.Face(Part.Wire(p.Shape.Edges))
     c4 = f.extrude(fc.Vector(0, 0, -obj.MagnetHoleDepth))
@@ -84,86 +72,40 @@ def _baseplate_magnet_hole_round(
     x_hole_pos: float,
     y_hole_pos: float,
 ) -> Part.Shape:
-    c1 = Part.makeCylinder(
-        obj.MagnetHoleDiameter / 2,
-        obj.MagnetHoleDepth,
-        fc.Vector(-x_hole_pos, -y_hole_pos, 0),
-        fc.Vector(0, 0, -1),
-    )
-    c2 = Part.makeCylinder(
-        obj.MagnetHoleDiameter / 2,
-        obj.MagnetHoleDepth,
-        fc.Vector(x_hole_pos, -y_hole_pos, 0),
-        fc.Vector(0, 0, -1),
-    )
-    c3 = Part.makeCylinder(
-        obj.MagnetHoleDiameter / 2,
-        obj.MagnetHoleDepth,
-        fc.Vector(-x_hole_pos, y_hole_pos, 0),
-        fc.Vector(0, 0, -1),
-    )
-    c4 = Part.makeCylinder(
-        obj.MagnetHoleDiameter / 2,
-        obj.MagnetHoleDepth,
-        fc.Vector(x_hole_pos, y_hole_pos, 0),
-        fc.Vector(0, 0, -1),
-    )
-
-    # Chamfer
-    ct1 = Part.makeCircle(
-        obj.MagnetHoleDiameter / 2 + obj.MagnetChamfer,
-        fc.Vector(-x_hole_pos, -y_hole_pos, 0),
-        fc.Vector(0, 0, 1),
-    )
-    ct2 = Part.makeCircle(
-        obj.MagnetHoleDiameter / 2 + obj.MagnetChamfer,
-        fc.Vector(x_hole_pos, -y_hole_pos, 0),
-        fc.Vector(0, 0, 1),
-    )
-    ct3 = Part.makeCircle(
-        obj.MagnetHoleDiameter / 2 + obj.MagnetChamfer,
-        fc.Vector(-x_hole_pos, y_hole_pos, 0),
-        fc.Vector(0, 0, 1),
-    )
-    ct4 = Part.makeCircle(
-        obj.MagnetHoleDiameter / 2 + obj.MagnetChamfer,
-        fc.Vector(x_hole_pos, y_hole_pos, 0),
-        fc.Vector(0, 0, 1),
-    )
-
-    cb1 = Part.makeCircle(
-        obj.MagnetHoleDiameter / 2,
-        fc.Vector(
-            -x_hole_pos,
-            -y_hole_pos,
-            -obj.MagnetChamfer,
-        ),
-        fc.Vector(0, 0, 1),
-    )
-    cb2 = Part.makeCircle(
-        obj.MagnetHoleDiameter / 2,
-        fc.Vector(x_hole_pos, -y_hole_pos, -obj.MagnetChamfer),
-        fc.Vector(0, 0, 1),
-    )
-    cb3 = Part.makeCircle(
-        obj.MagnetHoleDiameter / 2,
-        fc.Vector(-x_hole_pos, y_hole_pos, -obj.MagnetChamfer),
-        fc.Vector(0, 0, 1),
-    )
-    cb4 = Part.makeCircle(
-        obj.MagnetHoleDiameter / 2,
-        fc.Vector(x_hole_pos, y_hole_pos, -obj.MagnetChamfer),
-        fc.Vector(0, 0, 1),
-    )
-
-    ch = [
-        Part.makeLoft([ct1, cb1], solid=True),
-        Part.makeLoft([ct2, cb2], solid=True),
-        Part.makeLoft([ct3, cb3], solid=True),
-        Part.makeLoft([ct4, cb4], solid=True),
+    c = [
+        Part.makeCylinder(
+            obj.MagnetHoleDiameter / 2,
+            obj.MagnetHoleDepth,
+            pos,
+            fc.Vector(0, 0, -1),
+        )
+        for pos in utils.corners(x_hole_pos, y_hole_pos)
     ]
 
-    return c1.multiFuse([c2, c3, c4, *ch])
+    # Chamfer
+    ct = [
+        Part.makeCircle(
+            obj.MagnetHoleDiameter / 2 + obj.MagnetChamfer,
+            pos,
+            fc.Vector(0, 0, 1),
+        )
+        for pos in utils.corners(x_hole_pos, y_hole_pos)
+    ]
+    cb = [
+        Part.makeCircle(
+            obj.MagnetHoleDiameter / 2,
+            pos,
+            fc.Vector(0, 0, 1),
+        )
+        for pos in utils.corners(x_hole_pos, y_hole_pos, -obj.MagnetChamfer)
+    ]
+
+    ch = [
+        Part.makeLoft([t, b], solid=True)
+        for t, b in zip(ct, cb)
+    ]
+
+    return utils.multi_fuse(c + ch)
 
 
 class BaseplateMagnetHoles(utils.Feature):
@@ -291,33 +233,18 @@ class BaseplateMagnetHoles(utils.Feature):
             raise ValueError(f"Unexpected hole shape: {obj.MagnetHolesShape}")
 
         # Screw holes
-        ca1 = Part.makeCylinder(
-            obj.MagnetBaseHole / 2,
-            obj.MagnetHoleDepth + obj.BaseThickness,
-            fc.Vector(-x_hole_pos, -y_hole_pos, 0),
-            fc.Vector(0, 0, -1),
-        )
-        ca2 = Part.makeCylinder(
-            obj.MagnetBaseHole / 2,
-            obj.MagnetHoleDepth + obj.BaseThickness,
-            fc.Vector(x_hole_pos, -y_hole_pos, 0),
-            fc.Vector(0, 0, -1),
-        )
-        ca3 = Part.makeCylinder(
-            obj.MagnetBaseHole / 2,
-            obj.MagnetHoleDepth + obj.BaseThickness,
-            fc.Vector(-x_hole_pos, y_hole_pos, 0),
-            fc.Vector(0, 0, -1),
-        )
-        ca4 = Part.makeCylinder(
-            obj.MagnetBaseHole / 2,
-            obj.MagnetHoleDepth + obj.BaseThickness,
-            fc.Vector(x_hole_pos, y_hole_pos, 0),
-            fc.Vector(0, 0, -1),
-        )
+        ca = [
+            Part.makeCylinder(
+                obj.MagnetBaseHole / 2,
+                obj.MagnetHoleDepth + obj.BaseThickness,
+                pos,
+                fc.Vector(0, 0, -1),
+            )
+            for pos in utils.corners(x_hole_pos, -y_hole_pos)
+        ]
 
-        hm1 = hm1.multiFuse([ca1, ca2, ca3, ca4])
-        hm1.translate(fc.Vector(obj.xGridSize / 2, obj.yGridSize / 2, 0))
+        hm1 = hm1.multiFuse(ca)
+        hm1.translate(fc.Vector(obj.xGridSize / 2, obj.yGridSize / 2))
 
         xtranslate = zeromm
         ytranslate = zeromm
@@ -332,14 +259,14 @@ class BaseplateMagnetHoles(utils.Feature):
                     hm1_copy = hm1.copy()
 
                     # Translate for next hole
-                    hm1_copy.translate(fc.Vector(xtranslate, ytranslate, 0))
+                    hm1_copy.translate(fc.Vector(xtranslate, ytranslate))
                 hm2 = hm1_copy if hm2 is None else hm2.fuse(hm1_copy)
                 ytranslate += obj.yGridSize  # Track position
 
             hm3 = hm2 if hm3 is None else hm3.fuse(hm2)
             xtranslate += obj.xGridSize
 
-        return hm3.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
+        return hm3.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset))
 
 
 class BaseplateScrewBottomChamfer(utils.Feature):
@@ -383,73 +310,34 @@ class BaseplateScrewBottomChamfer(utils.Feature):
         x_hole_pos = obj.xGridSize / 2 - obj.MagnetHoleDistanceFromEdge
         y_hole_pos = obj.yGridSize / 2 - obj.MagnetHoleDistanceFromEdge
 
-        ct1 = Part.makeCircle(
-            obj.ScrewHoleDiameter / 2 + obj.MagnetBottomChamfer,
-            fc.Vector(-x_hole_pos, -y_hole_pos, -obj.TotalHeight + obj.BaseProfileHeight),
-            fc.Vector(0, 0, 1),
-        )
-        ct2 = Part.makeCircle(
-            obj.ScrewHoleDiameter / 2 + obj.MagnetBottomChamfer,
-            fc.Vector(x_hole_pos, -y_hole_pos, -obj.TotalHeight + obj.BaseProfileHeight),
-            fc.Vector(0, 0, 1),
-        )
-        ct3 = Part.makeCircle(
-            obj.ScrewHoleDiameter / 2 + obj.MagnetBottomChamfer,
-            fc.Vector(-x_hole_pos, y_hole_pos, -obj.TotalHeight + obj.BaseProfileHeight),
-            fc.Vector(0, 0, 1),
-        )
-        ct4 = Part.makeCircle(
-            obj.ScrewHoleDiameter / 2 + obj.MagnetBottomChamfer,
-            fc.Vector(x_hole_pos, y_hole_pos, -obj.TotalHeight + obj.BaseProfileHeight),
-            fc.Vector(0, 0, 1),
-        )
+        ct_z = -obj.TotalHeight + obj.BaseProfileHeight
+        ct = [
+            Part.makeCircle(
+                obj.ScrewHoleDiameter / 2 + obj.MagnetBottomChamfer,
+                pos,
+                fc.Vector(0, 0, 1),
+            )
+            for pos in utils.corners(x_hole_pos, y_hole_pos, ct_z)
+        ]
+        cb_z = -obj.TotalHeight + obj.MagnetBottomChamfer + obj.BaseProfileHeight
+        cb = [
+            Part.makeCircle(
+                obj.ScrewHoleDiameter / 2,
+                pos,
+                fc.Vector(0, 0, 1),
+            )
+            for pos in utils.corners(x_hole_pos, y_hole_pos, cb_z)
+        ]
 
-        cb1 = Part.makeCircle(
-            obj.ScrewHoleDiameter / 2,
-            fc.Vector(
-                -x_hole_pos,
-                -y_hole_pos,
-                -obj.TotalHeight + obj.MagnetBottomChamfer + obj.BaseProfileHeight,
-            ),
-            fc.Vector(0, 0, 1),
-        )
-        cb2 = Part.makeCircle(
-            obj.ScrewHoleDiameter / 2,
-            fc.Vector(
-                x_hole_pos,
-                -y_hole_pos,
-                -obj.TotalHeight + obj.MagnetBottomChamfer + obj.BaseProfileHeight,
-            ),
-            fc.Vector(0, 0, 1),
-        )
-        cb3 = Part.makeCircle(
-            obj.ScrewHoleDiameter / 2,
-            fc.Vector(
-                -x_hole_pos,
-                y_hole_pos,
-                -obj.TotalHeight + obj.MagnetBottomChamfer + obj.BaseProfileHeight,
-            ),
-            fc.Vector(0, 0, 1),
-        )
-        cb4 = Part.makeCircle(
-            obj.ScrewHoleDiameter / 2,
-            fc.Vector(
-                x_hole_pos,
-                y_hole_pos,
-                -obj.TotalHeight + obj.MagnetBottomChamfer + obj.BaseProfileHeight,
-            ),
-            fc.Vector(0, 0, 1),
-        )
-
-        ch1 = Part.makeLoft([ct1, cb1], solid=True)
-        ch2 = Part.makeLoft([ct2, cb2], solid=True)
-        ch3 = Part.makeLoft([ct3, cb3], solid=True)
-        ch4 = Part.makeLoft([ct4, cb4], solid=True)
+        ch = [
+            Part.makeLoft([t, b], solid=True)
+            for t, b in zip(ct, cb)
+        ]
 
         xtranslate = zeromm
         ytranslate = zeromm
 
-        hm1 = ch1.multiFuse([ch2, ch3, ch4])
+        hm1 = utils.multi_fuse(ch)
         hm2: Part.Shape | None = None
         hm3: Part.Shape | None = None
 
@@ -458,7 +346,7 @@ class BaseplateScrewBottomChamfer(utils.Feature):
             for y in range(obj.yMaxGrids):
                 if layout[x][y]:
                     hm1_copy = hm1.copy()
-                    hm1_copy.translate(fc.Vector(xtranslate, ytranslate, 0))
+                    hm1_copy.translate(fc.Vector(xtranslate, ytranslate))
                 hm2 = hm1_copy if hm2 is None else hm2.fuse(hm1_copy)
                 ytranslate += obj.yGridSize
             hm3 = hm2 if hm3 is None else hm3.fuse(hm2)
@@ -468,7 +356,6 @@ class BaseplateScrewBottomChamfer(utils.Feature):
             fc.Vector(
                 obj.xGridSize / 2 - obj.xLocationOffset,
                 obj.yGridSize / 2 - obj.yLocationOffset,
-                0,
             ),
         )
 
@@ -544,7 +431,7 @@ class BaseplateConnectionHoles(utils.Feature):
             ytranslate = zeromm
 
             hx1 = hx1.copy()
-            hx1.translate(fc.Vector(xtranslate, ytranslate, 0))
+            hx1.translate(fc.Vector(xtranslate, ytranslate))
             hx2 = hx1 if hx2 is None else hx2.fuse(hx1)
 
             xtranslate += obj.xGridSize
@@ -558,7 +445,7 @@ class BaseplateConnectionHoles(utils.Feature):
             xtranslate = zeromm
 
             hy1_copy = hy1.copy()
-            hy1_copy.translate(fc.Vector(xtranslate, ytranslate, 0))
+            hy1_copy.translate(fc.Vector(xtranslate, ytranslate))
             hy2 = hy1_copy if hy2 is None else hy2.fuse(hy1_copy)
             ytranslate += obj.yGridSize
 
@@ -567,7 +454,6 @@ class BaseplateConnectionHoles(utils.Feature):
             fc.Vector(
                 obj.xGridSize / 2 - obj.xLocationOffset,
                 obj.yGridSize / 2 - obj.yLocationOffset,
-                0,
             ),
         )
 
@@ -646,18 +532,18 @@ def _center_cut_wire(obj: fc.DocumentObject) -> None:
 
     mec_middle = fc.Vector(0, 0, 0)
 
-    v1 = fc.Vector(0, -y_inframedis, 0)
-    v2 = fc.Vector(-x_smfilloffcen, -y_inframedis, 0)
-    v3 = fc.Vector(-x_magedge, -y_smfillins, 0)
-    v4 = fc.Vector(-x_magedge, -y_magcenter, 0)
-    v5 = fc.Vector(-x_magcenter, -y_magedge, 0)
-    v6 = fc.Vector(-x_smfillins, -y_magedge, 0)
-    v7 = fc.Vector(-x_inframedis, -y_smfilloffcen, 0)
-    v8 = fc.Vector(-x_inframedis, 0, 0)
+    v1 = fc.Vector(0, -y_inframedis)
+    v2 = fc.Vector(-x_smfilloffcen, -y_inframedis)
+    v3 = fc.Vector(-x_magedge, -y_smfillins)
+    v4 = fc.Vector(-x_magedge, -y_magcenter)
+    v5 = fc.Vector(-x_magcenter, -y_magedge)
+    v6 = fc.Vector(-x_smfillins, -y_magedge)
+    v7 = fc.Vector(-x_inframedis, -y_smfilloffcen)
+    v8 = fc.Vector(-x_inframedis, 0)
 
-    va1 = fc.Vector(-x_smfillposmag, -y_smfillpos, 0)
-    va2 = fc.Vector(-x_bigfillpos, -y_bigfillpos, 0)
-    va3 = fc.Vector(-x_smfillpos, -y_smfillposmag, 0)
+    va1 = fc.Vector(-x_smfillposmag, -y_smfillpos)
+    va2 = fc.Vector(-x_bigfillpos, -y_bigfillpos)
+    va3 = fc.Vector(-x_smfillpos, -y_smfillposmag)
 
     l1 = Part.LineSegment(v1, v2)
     ar1 = Part.Arc(l1.EndPoint, va1, v3)
@@ -717,7 +603,7 @@ class BaseplateCenterCut(utils.Feature):
             ytranslate = 0
             for y in range(obj.yGridUnits):
                 if layout[x][y]:
-                    vec_list.append(fc.Vector(xtranslate, ytranslate, 0))
+                    vec_list.append(fc.Vector(xtranslate, ytranslate))
                 ytranslate += obj.yGridSize.Value
             xtranslate += obj.xGridSize.Value
 
@@ -727,7 +613,6 @@ class BaseplateCenterCut(utils.Feature):
             fc.Vector(
                 obj.xGridSize / 2 - obj.xLocationOffset,
                 obj.yGridSize / 2 - obj.yLocationOffset,
-                0,
             ),
         )
 
@@ -882,6 +767,6 @@ class BaseplateSolidShape(utils.Feature):
         face = Part.Face(baseplate_outside_shape)
 
         fuse_total = face.extrude(fc.Vector(0, 0, obj.TotalHeight))
-        fuse_total = fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
+        fuse_total = fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset))
 
         return fuse_total

--- a/freecad/gridfinity_workbench/baseplate_feature_construction.py
+++ b/freecad/gridfinity_workbench/baseplate_feature_construction.py
@@ -76,7 +76,7 @@ def _baseplate_magnet_hole_hex(
     c4 = f.extrude(fc.Vector(0, 0, -obj.MagnetHoleDepth))
     fc.ActiveDocument.removeObject(p.Name)
 
-    return Part.Solid.multiFuse(c1, [c2, c3, c4])
+    return c1.multiFuse([c2, c3, c4])
 
 
 def _baseplate_magnet_hole_round(
@@ -163,10 +163,7 @@ def _baseplate_magnet_hole_round(
         Part.makeLoft([ct4, cb4], solid=True),
     ]
 
-    return Part.Solid.multiFuse(
-        c1,
-        [c2, c3, c4, *ch],
-    )
+    return c1.multiFuse([c2, c3, c4, *ch])
 
 
 class BaseplateMagnetHoles(utils.Feature):
@@ -452,7 +449,7 @@ class BaseplateScrewBottomChamfer(utils.Feature):
         xtranslate = zeromm
         ytranslate = zeromm
 
-        hm1 = Part.Solid.multiFuse(ch1, [ch2, ch3, ch4])
+        hm1 = ch1.multiFuse([ch2, ch3, ch4])
         hm2: Part.Shape | None = None
         hm3: Part.Shape | None = None
 
@@ -540,7 +537,7 @@ class BaseplateConnectionHoles(utils.Feature):
 
         xtranslate = zeromm
         ytranslate = zeromm
-        hx1 = Part.Solid.fuse(c1, c2)
+        hx1 = c1.fuse(c2)
         hx2: Part.Shape | None = None
 
         for _ in range(obj.xMaxGrids):
@@ -554,7 +551,7 @@ class BaseplateConnectionHoles(utils.Feature):
 
         xtranslate = zeromm
         ytranslate = zeromm
-        hy1 = Part.Solid.fuse(c3, c4)
+        hy1 = c3.fuse(c4)
         hy2: Part.Shape | None = None
 
         for _ in range(obj.yMaxGrids):
@@ -565,7 +562,7 @@ class BaseplateConnectionHoles(utils.Feature):
             hy2 = hy1_copy if hy2 is None else hy2.fuse(hy1_copy)
             ytranslate += obj.yGridSize
 
-        fuse_total = Part.Solid.fuse(hx2, hy2)
+        fuse_total = hx2.fuse(hy2)
         fuse_total = fuse_total.translate(
             fc.Vector(
                 obj.xGridSize / 2 - obj.xLocationOffset,

--- a/freecad/gridfinity_workbench/baseplate_feature_construction.py
+++ b/freecad/gridfinity_workbench/baseplate_feature_construction.py
@@ -156,18 +156,16 @@ def _baseplate_magnet_hole_round(
         fc.Vector(0, 0, 1),
     )
 
-    ch1 = [ct1, cb1]
-    ch1 = Part.makeLoft(ch1, solid=True)
-    ch2 = [ct2, cb2]
-    ch2 = Part.makeLoft(ch2, solid=True)
-    ch3 = [ct3, cb3]
-    ch3 = Part.makeLoft(ch3, solid=True)
-    ch4 = [ct4, cb4]
-    ch4 = Part.makeLoft(ch4, solid=True)
+    ch = [
+        Part.makeLoft([ct1, cb1], solid=True),
+        Part.makeLoft([ct2, cb2], solid=True),
+        Part.makeLoft([ct3, cb3], solid=True),
+        Part.makeLoft([ct4, cb4], solid=True),
+    ]
 
     return Part.Solid.multiFuse(
         c1,
-        [c2, c3, c4, ch1, ch2, ch3, ch4],
+        [c2, c3, c4, *ch],
     )
 
 
@@ -263,7 +261,6 @@ class BaseplateMagnetHoles(utils.Feature):
             "Hidden",
             "Thickness of base under the normal baseplate  profile <br> <br> default = 6.4 mm",
         ).BaseThickness = const.BASE_THICKNESS
-
         obj.setEditorMode("BaseThickness", 2)
 
         obj.addProperty(
@@ -272,7 +269,6 @@ class BaseplateMagnetHoles(utils.Feature):
             "ShouldBeHidden",
             "MagnetHoles",
         ).MagnetHoles = const.MAGNET_HOLES
-
         obj.setEditorMode("MagnetHoles", 2)
 
     def make(self, obj: fc.DocumentObject, layout: GridfinityLayout) -> Part.Shape:
@@ -295,8 +291,7 @@ class BaseplateMagnetHoles(utils.Feature):
         elif obj.MagnetHolesShape == "Round":
             hm1 = _baseplate_magnet_hole_round(obj, x_hole_pos, y_hole_pos)
         else:
-            msg = f"Unexpected hole shape: {obj.MagnetHolesShape}"
-            raise ValueError(msg)
+            raise ValueError(f"Unexpected hole shape: {obj.MagnetHolesShape}")
 
         # Screw holes
         ca1 = Part.makeCylinder(
@@ -325,14 +320,7 @@ class BaseplateMagnetHoles(utils.Feature):
         )
 
         hm1 = hm1.multiFuse([ca1, ca2, ca3, ca4])
-
-        hm1.translate(
-            fc.Vector(
-                obj.xGridSize / 2,
-                obj.yGridSize / 2,
-                0,
-            ),
-        )
+        hm1.translate(fc.Vector(obj.xGridSize / 2, obj.yGridSize / 2, 0))
 
         xtranslate = zeromm
         ytranslate = zeromm
@@ -354,13 +342,7 @@ class BaseplateMagnetHoles(utils.Feature):
             hm3 = hm2 if hm3 is None else hm3.fuse(hm2)
             xtranslate += obj.xGridSize
 
-        return hm3.translate(
-            fc.Vector(
-                -obj.xLocationOffset,
-                -obj.yLocationOffset,
-                0,
-            ),
-        )
+        return hm3.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
 
 
 class BaseplateScrewBottomChamfer(utils.Feature):
@@ -462,14 +444,10 @@ class BaseplateScrewBottomChamfer(utils.Feature):
             fc.Vector(0, 0, 1),
         )
 
-        ch1 = [ct1, cb1]
-        ch1 = Part.makeLoft(ch1, solid=True)
-        ch2 = [ct2, cb2]
-        ch2 = Part.makeLoft(ch2, solid=True)
-        ch3 = [ct3, cb3]
-        ch3 = Part.makeLoft(ch3, solid=True)
-        ch4 = [ct4, cb4]
-        ch4 = Part.makeLoft(ch4, solid=True)
+        ch1 = Part.makeLoft([ct1, cb1], solid=True)
+        ch2 = Part.makeLoft([ct2, cb2], solid=True)
+        ch3 = Part.makeLoft([ct3, cb3], solid=True)
+        ch4 = Part.makeLoft([ct4, cb4], solid=True)
 
         xtranslate = zeromm
         ytranslate = zeromm
@@ -483,7 +461,6 @@ class BaseplateScrewBottomChamfer(utils.Feature):
             for y in range(obj.yMaxGrids):
                 if layout[x][y]:
                     hm1_copy = hm1.copy()
-
                     hm1_copy.translate(fc.Vector(xtranslate, ytranslate, 0))
                 hm2 = hm1_copy if hm2 is None else hm2.fuse(hm1_copy)
                 ytranslate += obj.yGridSize
@@ -589,14 +566,15 @@ class BaseplateConnectionHoles(utils.Feature):
             ytranslate += obj.yGridSize
 
         fuse_total = Part.Solid.fuse(hx2, hy2)
-
-        return fuse_total.translate(
+        fuse_total = fuse_total.translate(
             fc.Vector(
                 obj.xGridSize / 2 - obj.xLocationOffset,
                 obj.yGridSize / 2 - obj.yLocationOffset,
                 0,
             ),
         )
+
+        return fuse_total
 
 
 def _center_cut_wire(obj: fc.DocumentObject) -> None:
@@ -630,15 +608,12 @@ def _center_cut_wire(obj: fc.DocumentObject) -> None:
     )
 
     x_magcenter = obj.xGridSize / 2 - obj.MagnetHoleDistanceFromEdge
-
     y_magcenter = obj.yGridSize / 2 - obj.MagnetHoleDistanceFromEdge
 
     x_smfillpos = x_inframedis - obj.SmallFillet + obj.SmallFillet * math.sin(math.pi / 4)
-
     y_smfillpos = y_inframedis - obj.SmallFillet + obj.SmallFillet * math.sin(math.pi / 4)
 
     x_smfillposmag = x_magedge - obj.SmallFillet + obj.SmallFillet * math.sin(math.pi / 4)
-
     y_smfillposmag = y_magedge - obj.SmallFillet + obj.SmallFillet * math.sin(math.pi / 4)
 
     x_smfilloffcen = (
@@ -658,7 +633,6 @@ def _center_cut_wire(obj: fc.DocumentObject) -> None:
     )
 
     x_smfillins = x_inframedis - obj.SmallFillet
-
     y_smfillins = y_inframedis - obj.SmallFillet
 
     x_bigfillpos = (
@@ -702,7 +676,7 @@ def _center_cut_wire(obj: fc.DocumentObject) -> None:
 
 
 class BaseplateCenterCut(utils.Feature):
-    """Cut out the  center section of each baseplate grid."""
+    """Cut out the center section of each baseplate grid."""
 
     def __init__(self, obj: fc.DocumentObject) -> None:
         """Cut out the  center section of each baseplate grid.
@@ -911,11 +885,6 @@ class BaseplateSolidShape(utils.Feature):
         face = Part.Face(baseplate_outside_shape)
 
         fuse_total = face.extrude(fc.Vector(0, 0, obj.TotalHeight))
+        fuse_total = fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
 
-        return fuse_total.translate(
-            fc.Vector(
-                -obj.xLocationOffset,
-                -obj.yLocationOffset,
-                0,
-            ),
-        )
+        return fuse_total

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -59,8 +59,6 @@ def _label_shelf_full_width(
     )
     return funcfuse.cut(left_end_fillet)
 
-    return funcfuse
-
 
 def _label_shelf_center(
     obj: fc.DocumentObject,
@@ -78,7 +76,6 @@ def _label_shelf_center(
         ytranslate = ysp
         for y in range(ydiv):
             ls = face.extrude(fc.Vector(0, obj.LabelShelfLength, 0))
-
             ls.translate(fc.Vector(xtranslate, ytranslate, 0))
 
             if x == 0 and y == 0:
@@ -475,14 +472,9 @@ class LabelShelf(utils.Feature):
                 vec_list.append(fc.Vector(xtranslate, ytranslate, 0))
                 xtranslate += xcompwidth + obj.DividerThickness
 
-            funcfuse = Part.Shape.cut(funcfuse, utils.copy_and_translate(bottomcutbox, vec_list))
-        return funcfuse.translate(
-            fc.Vector(
-                -obj.xLocationOffset,
-                -obj.yLocationOffset,
-                0,
-            ),
-        )
+            funcfuse = funcfuse.cut(utils.copy_and_translate(bottomcutbox, vec_list))
+
+        return funcfuse.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
 
 
 class Scoop(utils.Feature):
@@ -649,13 +641,7 @@ class Scoop(utils.Feature):
             - 0.01 * unitmm,
             b_edges,
         )
-        return fuse_total.translate(
-            fc.Vector(
-                -obj.xLocationOffset,
-                -obj.yLocationOffset,
-                0,
-            ),
-        )
+        return fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
 
 
 def _make_compartments_no_deviders(
@@ -728,7 +714,6 @@ def _make_compartments_with_deviders(
 
     if xdiv:
         func_fuse = func_fuse.cut(xdiv)
-
     if ydiv:
         func_fuse = func_fuse.cut(ydiv)
 
@@ -848,25 +833,15 @@ class Compartments(utils.Feature):
 
         if obj.xDividerHeight < divmin and obj.xDividerHeight != 0:
             obj.xDividerHeight = divmin
-
             fc.Console.PrintWarning(
-                "Divider Height must be equal to or greater than:  ",
+                f"Divider Height must be equal to or greater than:  {divmin}\n",
             )
-
-            fc.Console.PrintWarning(divmin)
-
-            fc.Console.PrintWarning("\n")
 
         if obj.yDividerHeight < divmin and obj.yDividerHeight != 0:
             obj.yDividerHeight = divmin
-
             fc.Console.PrintWarning(
-                "Divider Height must be equal to or greater than:  ",
+                f"Divider Height must be equal to or greater than:  {divmin}\n",
             )
-
-            fc.Console.PrintWarning(divmin)
-
-            fc.Console.PrintWarning("\n")
 
         if (
             obj.xDividerHeight < obj.TotalHeight
@@ -875,7 +850,6 @@ class Compartments(utils.Feature):
             and obj.xDividers != 0
         ):
             obj.LabelShelfStyle = "Off"
-
             fc.Console.PrintWarning(
                 "Label Shelf turned off for less than full height x dividers",
             )
@@ -886,17 +860,10 @@ class Compartments(utils.Feature):
 
         if obj.xDividers == 0 and obj.yDividers == 0:
             func_fuse = _make_compartments_no_deviders(obj, func_fuse)
-
         else:
             func_fuse = _make_compartments_with_deviders(obj, func_fuse)
 
-        return func_fuse.translate(
-            fc.Vector(
-                -obj.xLocationOffset,
-                -obj.yLocationOffset,
-                0,
-            ),
-        )
+        return func_fuse.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
 
 
 def make_bottom_hole_shape(obj: fc.DocumentObject) -> Part.Shape:
@@ -1080,13 +1047,7 @@ def _eco_bin_deviders(obj: fc.DocumentObject) -> Part.Shape:
         assembly = comp if assembly is None else assembly.fuse(comp)
         ytranslate += ycomp_w + obj.DividerThickness
 
-    return assembly.translate(
-        fc.Vector(
-            obj.xGridSize / 2,
-            obj.yGridSize / 2,
-            0,
-        ),
-    )
+    return assembly.translate(fc.Vector(obj.xGridSize / 2, obj.yGridSize / 2, 0))
 
 
 def _eco_error_check(obj: fc.DocumentObject) -> None:
@@ -1096,29 +1057,18 @@ def _eco_error_check(obj: fc.DocumentObject) -> None:
 
     if obj.xDividerHeight < divmin and obj.xDividerHeight != 0:
         obj.xDividerHeight = divmin
-
         fc.Console.PrintWarning(
-            "Divider Height must be equal to or greater than:  ",
+            f"Divider Height must be equal to or greater than:  {divmin}\n",
         )
-
-        fc.Console.PrintWarning(divmin)
-
-        fc.Console.PrintWarning("\n")
 
     if obj.yDividerHeight < divmin and obj.yDividerHeight != 0:
         obj.yDividerHeight = divmin
-
         fc.Console.PrintWarning(
-            "Divider Height must be equal to or greater than:  ",
+            f"Divider Height must be equal to or greater than:  {divmin}\n",
         )
-
-        fc.Console.PrintWarning(divmin)
-
-        fc.Console.PrintWarning("\n")
 
     if obj.InsideFilletRadius > (1.6 * unitmm):
         obj.InsideFilletRadius = 1.6 * unitmm
-
         fc.Console.PrintWarning(
             "Inside Fillet Radius must be equal to or less than:  1.6 mm\n",
         )
@@ -1264,11 +1214,9 @@ class EcoCompartments(utils.Feature):
         )
 
         bt_chf_rad = obj.BinVerticalRadius - 0.4 * unitmm - obj.BaseWallThickness
-
         bt_chf_rad = 0.01 * unitmm if bt_chf_rad <= SMALL_NUMBER else bt_chf_rad
 
         v_chf_rad = obj.BinVerticalRadius - obj.BaseWallThickness
-
         v_chf_rad = 0.01 * unitmm if v_chf_rad <= SMALL_NUMBER else v_chf_rad
 
         magoffset, tp_chf_offset = zeromm, zeromm
@@ -1325,14 +1273,7 @@ class EcoCompartments(utils.Feature):
             xtranslate += obj.xGridSize
 
         eco_base_cut = utils.copy_and_translate(assembly, vec_list)
-
-        eco_base_cut.translate(
-            fc.Vector(
-                obj.xGridSize / 2,
-                obj.yGridSize / 2,
-                0,
-            ),
-        )
+        eco_base_cut.translate(fc.Vector(obj.xGridSize / 2, obj.yGridSize / 2, 0))
 
         func_fuse = func_fuse.fuse(eco_base_cut)
 
@@ -1369,9 +1310,7 @@ class EcoCompartments(utils.Feature):
         func_fuse = func_fuse.cut(outer_trim2)
 
         if obj.xDividers > 0 or obj.yDividers > 0:
-            deviders = _eco_bin_deviders(obj)
-
-            func_fuse = func_fuse.cut(deviders)
+            func_fuse = func_fuse.cut(_eco_bin_deviders(obj))
 
             b_edges = []
             divfil = -obj.TotalHeight + obj.BaseProfileHeight + obj.BaseWallThickness + 1 * unitmm
@@ -1383,13 +1322,8 @@ class EcoCompartments(utils.Feature):
                     b_edges.append(edge)
 
             func_fuse = func_fuse.makeFillet(obj.InsideFilletRadius / 2, b_edges)
-        return func_fuse.translate(
-            fc.Vector(
-                -obj.xLocationOffset,
-                -obj.yLocationOffset,
-                0,
-            ),
-        )
+
+        return func_fuse.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
 
 
 class BinBaseValues(utils.Feature):
@@ -1620,16 +1554,9 @@ class BlankBinRecessedTop(utils.Feature):
 
         """
         face = Part.Face(bin_inside_shape)
-
         fuse_total = face.extrude(fc.Vector(0, 0, -obj.RecessedTopDepth))
 
-        return fuse_total.translate(
-            fc.Vector(
-                -obj.xLocationOffset,
-                -obj.yLocationOffset,
-                0,
-            ),
-        )
+        return fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
 
 
 class BinBottomHoles(utils.Feature):
@@ -1771,13 +1698,7 @@ class BinBottomHoles(utils.Feature):
         fuse_total = utils.copy_and_translate(hole_shape_sub_array, vec_list).translate(
             fc.Vector(obj.xGridSize / 2, obj.yGridSize / 2, 0),
         )
-        return fuse_total.translate(
-            fc.Vector(
-                -obj.xLocationOffset,
-                -obj.yLocationOffset,
-                0,
-            ),
-        )
+        return fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
 
 
 class StackingLip(utils.Feature):
@@ -1908,31 +1829,27 @@ class StackingLip(utils.Feature):
         )
         st9 = fc.Vector(obj.Clearance + obj.WallThickness, obj.yGridSize / 2, 0)
 
-        stl1 = Part.LineSegment(st1, st2)
-        stl2 = Part.LineSegment(st2, st3)
-        stl3 = Part.LineSegment(st3, st4)
-        stl4 = Part.LineSegment(st4, st5)
-        stl5 = Part.LineSegment(st5, st6)
-        stl6 = Part.LineSegment(st6, st7)
-        stl7 = Part.LineSegment(st7, st8)
-        stl8 = Part.LineSegment(st8, st9)
-        stl9 = Part.LineSegment(st9, st1)
+        line_segments = [
+            Part.LineSegment(st1, st2),
+            Part.LineSegment(st2, st3),
+            Part.LineSegment(st3, st4),
+            Part.LineSegment(st4, st5),
+            Part.LineSegment(st5, st6),
+            Part.LineSegment(st6, st7),
+            Part.LineSegment(st7, st8),
+            Part.LineSegment(st8, st9),
+            Part.LineSegment(st9, st1),
+        ]
 
-        sts1 = Part.Shape([stl1, stl2, stl3, stl4, stl5, stl6, stl7, stl8, stl9])
-
-        wire = Part.Wire(sts1.Edges)
+        wire = Part.Wire(Part.Shape(line_segments).Edges)
 
         stacking_lip = Part.Wire(bin_outside_shape).makePipe(wire)
-
         stacking_lip = Part.makeSolid(stacking_lip)
-
-        return stacking_lip.translate(
-            fc.Vector(
-                -obj.xLocationOffset,
-                -obj.yLocationOffset,
-                0,
-            ),
+        stacking_lip = stacking_lip.translate(
+            fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0),
         )
+
+        return stacking_lip
 
 
 class BinSolidMidSection(utils.Feature):
@@ -2013,7 +1930,6 @@ class BinSolidMidSection(utils.Feature):
         ## Calculated Values
         if obj.NonStandardHeight:
             obj.TotalHeight = obj.CustomHeight
-
         else:
             obj.TotalHeight = obj.HeightUnits * obj.HeightUnitValue
 
@@ -2021,11 +1937,6 @@ class BinSolidMidSection(utils.Feature):
         face = Part.Face(bin_outside_shape)
 
         fuse_total = face.extrude(fc.Vector(0, 0, -obj.TotalHeight + obj.BaseProfileHeight))
+        fuse_total = fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
 
-        return fuse_total.translate(
-            fc.Vector(
-                -obj.xLocationOffset,
-                -obj.yLocationOffset,
-                0,
-            ),
-        )
+        return fuse_total

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -161,7 +161,9 @@ def _label_shelf_right(
     right_end_fillet = _label_shelf_right_fillet(obj)
     right_end_fillet = right_end_fillet.translate(
         fc.Vector(
-            0, obj.yTotalWidth - obj.WallThickness * 2 - obj.BinOuterRadius + obj.WallThickness, 0,
+            0,
+            obj.yTotalWidth - obj.WallThickness * 2 - obj.BinOuterRadius + obj.WallThickness,
+            0,
         ),
     )
     right_end_fillet = right_end_fillet.extrude(
@@ -1237,7 +1239,10 @@ class EcoCompartments(utils.Feature):
 
         func_fuse = func_fuse.fuse(eco_base_cut)
 
-        trim_tanslation = fc.Vector(obj.xTotalWidth / 2 + obj.Clearance, obj.yTotalWidth / 2 + obj.Clearance)
+        trim_tanslation = fc.Vector(
+            obj.xTotalWidth / 2 + obj.Clearance,
+            obj.yTotalWidth / 2 + obj.Clearance,
+        )
         outer_trim1 = utils.rounded_rectangle_extrude(
             obj.xTotalWidth - obj.WallThickness * 2,
             obj.yTotalWidth - obj.WallThickness * 2,
@@ -1622,7 +1627,8 @@ class BinBottomHoles(utils.Feature):
         y_hole_pos = obj.yGridSize / 2 - obj.MagnetHoleDistanceFromEdge
 
         hole_shape_sub_array = utils.copy_and_translate(
-            bottom_hole_shape, utils.corners(x_hole_pos, y_hole_pos, -obj.TotalHeight),
+            bottom_hole_shape,
+            utils.corners(x_hole_pos, y_hole_pos, -obj.TotalHeight),
         )
         vec_list = []
         xtranslate = 0
@@ -1735,7 +1741,7 @@ class StackingLip(utils.Feature):
                 obj.yGridSize / 2,
                 obj.StackingLipBottomChamfer + obj.StackingLipVerticalSection,
             ),
-                fc.Vector(
+            fc.Vector(
                 obj.Clearance + obj.StackingLipTopLedge + obj.StackingLipTopChamfer,
                 obj.yGridSize / 2,
                 obj.StackingLipBottomChamfer,

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -27,9 +27,9 @@ def _label_shelf_full_width(
     xtranslate = zeromm
     parts = []
     for x in range(xdiv):
-        ls = face.extrude(fc.Vector(0, fw, 0))
+        ls = face.extrude(fc.Vector(0, fw))
 
-        ls.translate(fc.Vector(xtranslate, ytranslate, 0))
+        ls.translate(fc.Vector(xtranslate, ytranslate))
 
         if x == 0:
             firstls = ls
@@ -45,7 +45,6 @@ def _label_shelf_full_width(
         fc.Vector(
             0,
             obj.yTotalWidth - obj.WallThickness * 2 - obj.BinOuterRadius + obj.WallThickness,
-            0,
         ),
     )
     right_end_fillet = right_end_fillet.extrude(
@@ -75,8 +74,8 @@ def _label_shelf_center(
     for x in range(xdiv):
         ytranslate = ysp
         for y in range(ydiv):
-            ls = face.extrude(fc.Vector(0, obj.LabelShelfLength, 0))
-            ls.translate(fc.Vector(xtranslate, ytranslate, 0))
+            ls = face.extrude(fc.Vector(0, obj.LabelShelfLength))
+            ls.translate(fc.Vector(xtranslate, ytranslate))
 
             if x == 0 and y == 0:
                 firstls = ls
@@ -106,9 +105,9 @@ def _label_shelf_left(
     for x in range(xdiv):
         ytranslate = ysp
         for y in range(ydiv):
-            ls = face.extrude(fc.Vector(0, obj.LabelShelfLength, 0))
+            ls = face.extrude(fc.Vector(0, obj.LabelShelfLength))
 
-            ls.translate(fc.Vector(xtranslate, ytranslate, 0))
+            ls.translate(fc.Vector(xtranslate, ytranslate))
 
             if x == 0 and y == 0:
                 firstls = ls
@@ -144,9 +143,9 @@ def _label_shelf_right(
     for x in range(xdiv):
         ytranslate = ysp
         for y in range(ydiv):
-            ls = face.extrude(fc.Vector(0, obj.LabelShelfLength, 0))
+            ls = face.extrude(fc.Vector(0, obj.LabelShelfLength))
 
-            ls.translate(fc.Vector(xtranslate, ytranslate, 0))
+            ls.translate(fc.Vector(xtranslate, ytranslate))
 
             if x == 0 and y == 0:
                 firstls = ls
@@ -162,9 +161,7 @@ def _label_shelf_right(
     right_end_fillet = _label_shelf_right_fillet(obj)
     right_end_fillet = right_end_fillet.translate(
         fc.Vector(
-            0,
-            obj.yTotalWidth - obj.WallThickness * 2 - obj.BinOuterRadius + obj.WallThickness,
-            0,
+            0, obj.yTotalWidth - obj.WallThickness * 2 - obj.BinOuterRadius + obj.WallThickness, 0,
         ),
     )
     right_end_fillet = right_end_fillet.extrude(
@@ -226,11 +223,11 @@ def _label_shelf_left_fillet(
     l2x2 = l1x
     l2y = l1y1
 
-    l1v1 = fc.Vector(l1x, l1y1, 0)
-    l1v2 = fc.Vector(l1x, l1y2, 0)
-    arc1v = fc.Vector(arc1x, arc1y, 0)
-    l2v1 = fc.Vector(l2x1, l2y, 0)
-    l2v2 = fc.Vector(l2x2, l2y, 0)
+    l1v1 = fc.Vector(l1x, l1y1)
+    l1v2 = fc.Vector(l1x, l1y2)
+    arc1v = fc.Vector(arc1x, arc1y)
+    l2v1 = fc.Vector(l2x1, l2y)
+    l2v2 = fc.Vector(l2x2, l2y)
 
     lines = [
         Part.LineSegment(l1v1, l1v2),
@@ -263,11 +260,11 @@ def _label_shelf_right_fillet(
     )
     arc1y = obj.Clearance + obj.WallThickness + fillet_radius * math.sin(math.pi / 4)
 
-    l1v1 = fc.Vector(l1x, l1y1, 0)
-    l1v2 = fc.Vector(l1x, l1y2, 0)
-    l2v1 = fc.Vector(l2x1, l2y, 0)
-    l2v2 = fc.Vector(l2x2, l2y, 0)
-    arc1v = fc.Vector(arc1x, arc1y, 0)
+    l1v1 = fc.Vector(l1x, l1y1)
+    l1v2 = fc.Vector(l1x, l1y2)
+    l2v1 = fc.Vector(l2x1, l2y)
+    l2v2 = fc.Vector(l2x2, l2y)
+    arc1v = fc.Vector(arc1x, arc1y)
 
     lines = [
         Part.LineSegment(l1v1, l1v2),
@@ -415,19 +412,14 @@ class LabelShelf(utils.Feature):
         side_b = math.sqrt(-pow(side_a, 2) + pow(side_c, 2))
         v4_z = -obj.LabelShelfVerticalThickness - side_b * unitmm
 
-        v1 = fc.Vector(towall, 0, stackingoffset)
-        v2 = fc.Vector(tolabelend, 0, stackingoffset)
-        v3 = fc.Vector(tolabelend, 0, -obj.LabelShelfVerticalThickness + stackingoffset)
-        v4 = fc.Vector(towall, 0, v4_z + stackingoffset)
-
-        lines = [
-            Part.LineSegment(v1, v2),
-            Part.LineSegment(v2, v3),
-            Part.LineSegment(v3, v4),
-            Part.LineSegment(v4, v1),
+        v = [
+            fc.Vector(towall, 0, stackingoffset),
+            fc.Vector(tolabelend, 0, stackingoffset),
+            fc.Vector(tolabelend, 0, -obj.LabelShelfVerticalThickness + stackingoffset),
+            fc.Vector(towall, 0, v4_z + stackingoffset),
         ]
 
-        wire = utils.curve_to_wire(lines)
+        wire = utils.curve_to_wire(utils.loop(v))
 
         face = Part.Face(wire)
 
@@ -469,12 +461,12 @@ class LabelShelf(utils.Feature):
 
             vec_list = []
             for _ in range(xdiv):
-                vec_list.append(fc.Vector(xtranslate, ytranslate, 0))
+                vec_list.append(fc.Vector(xtranslate, ytranslate))
                 xtranslate += xcompwidth + obj.DividerThickness
 
             funcfuse = funcfuse.cut(utils.copy_and_translate(bottomcutbox, vec_list))
 
-        return funcfuse.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
+        return funcfuse.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset))
 
 
 class Scoop(utils.Feature):
@@ -596,16 +588,15 @@ class Scoop(utils.Feature):
             fc.Vector(
                 obj.xTotalWidth + obj.Clearance - obj.WallThickness,
                 +obj.Clearance + obj.WallThickness,
-                0,
             ),
             fc.Vector(0, 0, -1),
         )
 
-        scoop = face.extrude(fc.Vector(0, obj.yTotalWidth - obj.WallThickness * 2, 0))
+        scoop = face.extrude(fc.Vector(0, obj.yTotalWidth - obj.WallThickness * 2))
 
         vec_list = []
         for x in range(xdiv):
-            vec_list.append(fc.Vector(-xtranslate, obj.Clearance + obj.WallThickness, 0))
+            vec_list.append(fc.Vector(-xtranslate, obj.Clearance + obj.WallThickness))
 
             if x > 0:
                 xtranslate += compwidth + obj.DividerThickness
@@ -641,7 +632,7 @@ class Scoop(utils.Feature):
             - 0.01 * unitmm,
             b_edges,
         )
-        return fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
+        return fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset))
 
 
 def _make_compartments_no_deviders(
@@ -693,7 +684,7 @@ def _make_compartments_with_deviders(
             ),
             fc.Vector(0, 0, 1),
         )
-        comp.translate(fc.Vector(xtranslate, 0, 0))
+        comp.translate(fc.Vector(xtranslate, 0))
         xdiv = comp if xdiv is None else xdiv.fuse(comp)
         xtranslate += xcomp_w + obj.DividerThickness
 
@@ -708,7 +699,7 @@ def _make_compartments_with_deviders(
             fc.Vector(0, 0, 1),
         )
 
-        comp.translate(fc.Vector(0, ytranslate, 0))
+        comp.translate(fc.Vector(0, ytranslate))
         ydiv = comp if ydiv is None else ydiv.fuse(comp)
         ytranslate += ycomp_w + obj.DividerThickness
 
@@ -863,7 +854,7 @@ class Compartments(utils.Feature):
         else:
             func_fuse = _make_compartments_with_deviders(obj, func_fuse)
 
-        return func_fuse.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
+        return func_fuse.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset))
 
 
 def make_bottom_hole_shape(obj: fc.DocumentObject) -> Part.Shape:
@@ -929,7 +920,7 @@ def make_bottom_hole_shape(obj: fc.DocumentObject) -> Part.Shape:
             obj.ScrewHoleDiameter,
             obj.ScrewHoleDiameter,
             sqbr2_depth,
-            fc.Vector(-obj.ScrewHoleDiameter / 2, -obj.ScrewHoleDiameter / 2, 0),
+            fc.Vector(-obj.ScrewHoleDiameter / 2, -obj.ScrewHoleDiameter / 2),
             fc.Vector(0, 0, 1),
         )
         arc_pt_off_x = (
@@ -939,36 +930,12 @@ def make_bottom_hole_shape(obj: fc.DocumentObject) -> Part.Shape:
         ) * unitmm
         arc_pt_off_y = obj.ScrewHoleDiameter / 2
 
-        va1 = fc.Vector(
-            arc_pt_off_x,
-            arc_pt_off_y,
-            0,
-        )
-        va2 = fc.Vector(
-            -arc_pt_off_x,
-            arc_pt_off_y,
-            0,
-        )
-        va3 = fc.Vector(
-            -arc_pt_off_x,
-            -arc_pt_off_y,
-            0,
-        )
-        va4 = fc.Vector(
-            arc_pt_off_x,
-            -arc_pt_off_y,
-            0,
-        )
-        var1 = fc.Vector(
-            obj.MagnetHoleDiameter / 2,
-            0,
-            0,
-        )
-        var2 = fc.Vector(
-            -obj.MagnetHoleDiameter / 2,
-            0,
-            0,
-        )
+        va1 = fc.Vector(arc_pt_off_x, arc_pt_off_y)
+        va2 = fc.Vector(-arc_pt_off_x, arc_pt_off_y)
+        va3 = fc.Vector(-arc_pt_off_x, -arc_pt_off_y)
+        va4 = fc.Vector(arc_pt_off_x, -arc_pt_off_y)
+        var1 = fc.Vector(obj.MagnetHoleDiameter / 2, 0)
+        var2 = fc.Vector(-obj.MagnetHoleDiameter / 2, 0)
         line_1 = Part.LineSegment(va1, va2)
         line_2 = Part.LineSegment(va3, va4)
         ar1 = Part.Arc(va1, var1, va4)
@@ -1018,7 +985,7 @@ def _eco_bin_deviders(obj: fc.DocumentObject) -> Part.Shape:
             ),
             fc.Vector(0, 0, 1),
         )
-        comp.translate(fc.Vector(xtranslate, 0, 0))
+        comp.translate(fc.Vector(xtranslate, 0))
 
         assembly = comp if assembly is None else assembly.fuse(comp)
         xtranslate += xcomp_w + obj.DividerThickness
@@ -1036,11 +1003,11 @@ def _eco_bin_deviders(obj: fc.DocumentObject) -> Part.Shape:
             ),
             fc.Vector(0, 0, 1),
         )
-        comp.translate(fc.Vector(0, ytranslate, 0))
+        comp.translate(fc.Vector(0, ytranslate))
         assembly = comp if assembly is None else assembly.fuse(comp)
         ytranslate += ycomp_w + obj.DividerThickness
 
-    return assembly.translate(fc.Vector(obj.xGridSize / 2, obj.yGridSize / 2, 0))
+    return assembly.translate(fc.Vector(obj.xGridSize / 2, obj.yGridSize / 2))
 
 
 def _eco_error_check(obj: fc.DocumentObject) -> None:
@@ -1261,28 +1228,23 @@ class EcoCompartments(utils.Feature):
             ytranslate = zeromm
             for y in range(obj.yMaxGrids):
                 if layout[x][y]:
-                    vec_list.append(fc.Vector(xtranslate, ytranslate, 0))
+                    vec_list.append(fc.Vector(xtranslate, ytranslate))
                 ytranslate += obj.yGridSize
             xtranslate += obj.xGridSize
 
         eco_base_cut = utils.copy_and_translate(assembly, vec_list)
-        eco_base_cut.translate(fc.Vector(obj.xGridSize / 2, obj.yGridSize / 2, 0))
+        eco_base_cut.translate(fc.Vector(obj.xGridSize / 2, obj.yGridSize / 2))
 
         func_fuse = func_fuse.fuse(eco_base_cut)
 
+        trim_tanslation = fc.Vector(obj.xTotalWidth / 2 + obj.Clearance, obj.yTotalWidth / 2 + obj.Clearance)
         outer_trim1 = utils.rounded_rectangle_extrude(
             obj.xTotalWidth - obj.WallThickness * 2,
             obj.yTotalWidth - obj.WallThickness * 2,
             -obj.TotalHeight,
             obj.TotalHeight,
             obj.BinOuterRadius - obj.WallThickness,
-        ).translate(
-            fc.Vector(
-                obj.xTotalWidth / 2 + obj.Clearance,
-                obj.yTotalWidth / 2 + obj.Clearance,
-                0,
-            ),
-        )
+        ).translate(trim_tanslation)
 
         outer_trim2 = utils.rounded_rectangle_extrude(
             obj.xTotalWidth + 20 * unitmm,
@@ -1290,13 +1252,7 @@ class EcoCompartments(utils.Feature):
             -obj.TotalHeight,
             obj.TotalHeight - obj.BaseProfileHeight,
             obj.BinOuterRadius,
-        ).translate(
-            fc.Vector(
-                obj.xTotalWidth / 2 + obj.Clearance,
-                obj.yTotalWidth / 2 + obj.Clearance,
-                0,
-            ),
-        )
+        ).translate(trim_tanslation)
 
         outer_trim2 = outer_trim2.cut(outer_trim1)
 
@@ -1316,7 +1272,7 @@ class EcoCompartments(utils.Feature):
 
             func_fuse = func_fuse.makeFillet(obj.InsideFilletRadius / 2, b_edges)
 
-        return func_fuse.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
+        return func_fuse.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset))
 
 
 class BinBaseValues(utils.Feature):
@@ -1490,7 +1446,7 @@ def make_complex_bin_base(
         for y in range(obj.yMaxGrids):
             if layout[x][y]:
                 b = assembly.copy()
-                b.translate(fc.Vector(xtranslate, ytranslate, 0))
+                b.translate(fc.Vector(xtranslate, ytranslate))
 
             if x == 0 and y == 0:
                 b1 = b
@@ -1509,11 +1465,7 @@ def make_complex_bin_base(
     )
 
     return fuse_total.translate(
-        fc.Vector(
-            obj.xGridSize / 2 - obj.xLocationOffset,
-            obj.yGridSize / 2 - obj.yLocationOffset,
-            0,
-        ),
+        fc.Vector(obj.xGridSize / 2 - obj.xLocationOffset, obj.yGridSize / 2 - obj.yLocationOffset),
     )
 
 
@@ -1549,7 +1501,7 @@ class BlankBinRecessedTop(utils.Feature):
         face = Part.Face(bin_inside_shape)
         fuse_total = face.extrude(fc.Vector(0, 0, -obj.RecessedTopDepth))
 
-        return fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
+        return fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset))
 
 
 class BinBottomHoles(utils.Feature):
@@ -1670,13 +1622,7 @@ class BinBottomHoles(utils.Feature):
         y_hole_pos = obj.yGridSize / 2 - obj.MagnetHoleDistanceFromEdge
 
         hole_shape_sub_array = utils.copy_and_translate(
-            bottom_hole_shape,
-            [
-                fc.Vector(-x_hole_pos, -y_hole_pos, -obj.TotalHeight),
-                fc.Vector(x_hole_pos, -y_hole_pos, -obj.TotalHeight),
-                fc.Vector(-x_hole_pos, y_hole_pos, -obj.TotalHeight),
-                fc.Vector(x_hole_pos, y_hole_pos, -obj.TotalHeight),
-            ],
+            bottom_hole_shape, utils.corners(x_hole_pos, y_hole_pos, -obj.TotalHeight),
         )
         vec_list = []
         xtranslate = 0
@@ -1684,14 +1630,14 @@ class BinBottomHoles(utils.Feature):
             ytranslate = 0
             for y in range(obj.yMaxGrids):
                 if layout[x][y]:
-                    vec_list.append(fc.Vector(xtranslate, ytranslate, 0))
+                    vec_list.append(fc.Vector(xtranslate, ytranslate))
                 ytranslate += obj.yGridSize.Value
             xtranslate += obj.xGridSize.Value
 
         fuse_total = utils.copy_and_translate(hole_shape_sub_array, vec_list).translate(
-            fc.Vector(obj.xGridSize / 2, obj.yGridSize / 2, 0),
+            fc.Vector(obj.xGridSize / 2, obj.yGridSize / 2),
         )
-        return fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
+        return fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset))
 
 
 class StackingLip(utils.Feature):
@@ -1768,78 +1714,68 @@ class StackingLip(utils.Feature):
         )
 
         ## Stacking Lip Generation
-        st1 = fc.Vector(obj.Clearance, obj.yGridSize / 2, 0)
-        st2 = fc.Vector(
-            obj.Clearance,
-            obj.yGridSize / 2,
-            obj.StackingLipBottomChamfer
-            + obj.StackingLipVerticalSection
-            + obj.StackingLipTopChamfer,
-        )
-        st3 = fc.Vector(
-            obj.Clearance + obj.StackingLipTopLedge,
-            obj.yGridSize / 2,
-            obj.StackingLipBottomChamfer
-            + obj.StackingLipVerticalSection
-            + obj.StackingLipTopChamfer,
-        )
-        st4 = fc.Vector(
-            obj.Clearance + obj.StackingLipTopLedge + obj.StackingLipTopChamfer,
-            obj.yGridSize / 2,
-            obj.StackingLipBottomChamfer + obj.StackingLipVerticalSection,
-        )
-        st5 = fc.Vector(
-            obj.Clearance + obj.StackingLipTopLedge + obj.StackingLipTopChamfer,
-            obj.yGridSize / 2,
-            obj.StackingLipBottomChamfer,
-        )
-        st6 = fc.Vector(
-            obj.Clearance
-            + obj.StackingLipTopLedge
-            + obj.StackingLipTopChamfer
-            + obj.StackingLipBottomChamfer,
-            obj.yGridSize / 2,
-            0,
-        )
-        st7 = fc.Vector(
-            obj.Clearance
-            + obj.StackingLipTopLedge
-            + obj.StackingLipTopChamfer
-            + obj.StackingLipBottomChamfer,
-            obj.yGridSize / 2,
-            -obj.StackingLipVerticalSection,
-        )
-        st8 = fc.Vector(
-            obj.Clearance + obj.WallThickness,
-            obj.yGridSize / 2,
-            -obj.StackingLipVerticalSection
-            - (
-                obj.StackingLipTopLedge
-                + obj.StackingLipTopChamfer
-                + obj.StackingLipBottomChamfer
-                - obj.WallThickness
+        st = [
+            fc.Vector(obj.Clearance, obj.yGridSize / 2, 0),
+            fc.Vector(
+                obj.Clearance,
+                obj.yGridSize / 2,
+                obj.StackingLipBottomChamfer
+                + obj.StackingLipVerticalSection
+                + obj.StackingLipTopChamfer,
             ),
-        )
-        st9 = fc.Vector(obj.Clearance + obj.WallThickness, obj.yGridSize / 2, 0)
-
-        line_segments = [
-            Part.LineSegment(st1, st2),
-            Part.LineSegment(st2, st3),
-            Part.LineSegment(st3, st4),
-            Part.LineSegment(st4, st5),
-            Part.LineSegment(st5, st6),
-            Part.LineSegment(st6, st7),
-            Part.LineSegment(st7, st8),
-            Part.LineSegment(st8, st9),
-            Part.LineSegment(st9, st1),
+            fc.Vector(
+                obj.Clearance + obj.StackingLipTopLedge,
+                obj.yGridSize / 2,
+                obj.StackingLipBottomChamfer
+                + obj.StackingLipVerticalSection
+                + obj.StackingLipTopChamfer,
+            ),
+            fc.Vector(
+                obj.Clearance + obj.StackingLipTopLedge + obj.StackingLipTopChamfer,
+                obj.yGridSize / 2,
+                obj.StackingLipBottomChamfer + obj.StackingLipVerticalSection,
+            ),
+                fc.Vector(
+                obj.Clearance + obj.StackingLipTopLedge + obj.StackingLipTopChamfer,
+                obj.yGridSize / 2,
+                obj.StackingLipBottomChamfer,
+            ),
+            fc.Vector(
+                obj.Clearance
+                + obj.StackingLipTopLedge
+                + obj.StackingLipTopChamfer
+                + obj.StackingLipBottomChamfer,
+                obj.yGridSize / 2,
+                0,
+            ),
+            fc.Vector(
+                obj.Clearance
+                + obj.StackingLipTopLedge
+                + obj.StackingLipTopChamfer
+                + obj.StackingLipBottomChamfer,
+                obj.yGridSize / 2,
+                -obj.StackingLipVerticalSection,
+            ),
+            fc.Vector(
+                obj.Clearance + obj.WallThickness,
+                obj.yGridSize / 2,
+                -obj.StackingLipVerticalSection
+                - (
+                    obj.StackingLipTopLedge
+                    + obj.StackingLipTopChamfer
+                    + obj.StackingLipBottomChamfer
+                    - obj.WallThickness
+                ),
+            ),
+            fc.Vector(obj.Clearance + obj.WallThickness, obj.yGridSize / 2, 0),
         ]
 
-        wire = Part.Wire(Part.Shape(line_segments).Edges)
+        wire = Part.Wire(Part.Shape(utils.loop(st)).Edges)
 
         stacking_lip = Part.Wire(bin_outside_shape).makePipe(wire)
         stacking_lip = Part.makeSolid(stacking_lip)
         stacking_lip = stacking_lip.translate(
-            fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0),
+            fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset),
         )
 
         return stacking_lip
@@ -1930,6 +1866,6 @@ class BinSolidMidSection(utils.Feature):
         face = Part.Face(bin_outside_shape)
 
         fuse_total = face.extrude(fc.Vector(0, 0, -obj.TotalHeight + obj.BaseProfileHeight))
-        fuse_total = fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset, 0))
+        fuse_total = fuse_total.translate(fc.Vector(-obj.xLocationOffset, -obj.yLocationOffset))
 
         return fuse_total

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -987,13 +987,6 @@ def make_bottom_hole_shape(obj: fc.DocumentObject) -> Part.Shape:
     return bottom_hole_shape
 
 
-def _eco_bin_cut_fillet_edges_filter(obj: fc.DocumentObject, edge: Part.Edge) -> bool:
-    divfil = -obj.TotalHeight + obj.BaseProfileHeight + obj.BaseWallThickness + 1 * unitmm
-    z0 = edge.Vertexes[0].Point.z
-    z1 = edge.Vertexes[1].Point.z
-    return z1 != z0 and (z1 >= divfil or z0 >= divfil)
-
-
 def _eco_bin_deviders(obj: fc.DocumentObject) -> Part.Shape:
     xcomp_w = (obj.xTotalWidth - obj.WallThickness * 2 - obj.xDividers * obj.DividerThickness) / (
         obj.xDividers + 1
@@ -1478,7 +1471,7 @@ def make_complex_bin_base(
         obj.BaseProfileVerticalSection,
         obj.BinVerticalRadius,
     )
-    assembly = Part.Shape.fuse(bottom_chamfer, vertical_section)
+    assembly = bottom_chamfer.fuse(vertical_section)
 
     top_chamfer = utils.rounded_rectangle_chamfer(
         x_vert_width,

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -38,7 +38,7 @@ def _label_shelf_full_width(
 
         xtranslate += xcompwidth + obj.DividerThickness
 
-    funcfuse = ls if xdiv == 1 else Part.Solid.multiFuse(firstls, parts)
+    funcfuse = ls if xdiv == 1 else firstls.multiFuse(parts)
 
     right_end_fillet = _label_shelf_right_fillet(obj)
     right_end_fillet = right_end_fillet.translate(
@@ -87,7 +87,7 @@ def _label_shelf_center(
 
         xtranslate += xcompwidth + obj.DividerThickness
 
-    return ls if xdiv == 1 and ydiv == 1 else Part.Solid.multiFuse(firstls, parts)
+    return ls if xdiv == 1 and ydiv == 1 else firstls.multiFuse(parts)
 
 
 def _label_shelf_left(
@@ -119,7 +119,7 @@ def _label_shelf_left(
 
         xtranslate += xcompwidth + obj.DividerThickness
 
-    funcfuse = ls if xdiv == 1 and ydiv == 1 else Part.Solid.multiFuse(firstls, parts)
+    funcfuse = ls if xdiv == 1 and ydiv == 1 else firstls.multiFuse(parts)
 
     left_end_fillet = _label_shelf_left_fillet(obj)
     left_end_fillet = left_end_fillet.extrude(
@@ -157,7 +157,7 @@ def _label_shelf_right(
 
         xtranslate += xcompwidth + obj.DividerThickness
 
-    funcfuse = ls if xdiv == 1 and ydiv == 1 else Part.Solid.multiFuse(firstls, parts)
+    funcfuse = ls if xdiv == 1 and ydiv == 1 else firstls.multiFuse(parts)
 
     right_end_fillet = _label_shelf_right_fillet(obj)
     right_end_fillet = right_end_fillet.translate(
@@ -977,7 +977,7 @@ def make_bottom_hole_shape(obj: fc.DocumentObject) -> Part.Shape:
         w1 = Part.Wire(s1.Edges)
         sq1_1 = Part.Face(w1)
         sq1_1 = sq1_1.extrude(fc.Vector(0, 0, sqbr1_depth))
-        holes_interface_shape = Part.Solid.fuse(sq1_1, b1)
+        holes_interface_shape = sq1_1.fuse(b1)
 
         bottom_hole_shape = (
             holes_interface_shape
@@ -1481,7 +1481,7 @@ def make_complex_bin_base(
         obj.BinVerticalRadius,
     )
 
-    assembly = Part.Solid.multiFuse(bottom_chamfer, [vertical_section, top_chamfer])
+    assembly = bottom_chamfer.multiFuse([vertical_section, top_chamfer])
 
     parts = []
 
@@ -1505,7 +1505,7 @@ def make_complex_bin_base(
     fuse_total = (
         b1
         if obj.xMaxGrids < larger_than_single_grid and obj.yMaxGrids < larger_than_single_grid
-        else Part.Solid.multiFuse(b1, parts)
+        else b1.multiFuse(parts)
     )
 
     return fuse_total.translate(

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -148,11 +148,7 @@ class BinBlank(FoundationGridfinity):
             obj.BinOuterRadius,
         )
         bin_outside_shape.translate(
-            fc.Vector(
-                obj.xTotalWidth / 2 + obj.Clearance,
-                obj.yTotalWidth / 2 + obj.Clearance,
-                0,
-            ),
+            fc.Vector(obj.xTotalWidth / 2 + obj.Clearance, obj.yTotalWidth / 2 + obj.Clearance),
         )
 
         bin_inside_shape = utils.create_rounded_rectangle(
@@ -162,11 +158,7 @@ class BinBlank(FoundationGridfinity):
             obj.BinOuterRadius - obj.WallThickness,
         )
         bin_inside_shape.translate(
-            fc.Vector(
-                obj.xTotalWidth / 2 + obj.Clearance,
-                obj.yTotalWidth / 2 + obj.Clearance,
-                0,
-            ),
+            fc.Vector(obj.xTotalWidth / 2 + obj.Clearance, obj.yTotalWidth / 2 + obj.Clearance),
         )
 
         fuse_total = BinSolidMidSection.make(self, obj, bin_outside_shape)
@@ -503,11 +495,7 @@ class PartsBin(FoundationGridfinity):
             obj.BinOuterRadius,
         )
         bin_outside_shape.translate(
-            fc.Vector(
-                obj.xTotalWidth / 2 + obj.Clearance,
-                obj.yTotalWidth / 2 + obj.Clearance,
-                0,
-            ),
+            fc.Vector(obj.xTotalWidth / 2 + obj.Clearance, obj.yTotalWidth / 2 + obj.Clearance, 0),
         )
 
         bin_inside_shape = utils.create_rounded_rectangle(
@@ -517,11 +505,7 @@ class PartsBin(FoundationGridfinity):
             obj.BinOuterRadius - obj.WallThickness,
         )
         bin_inside_shape.translate(
-            fc.Vector(
-                obj.xTotalWidth / 2 + obj.Clearance,
-                obj.yTotalWidth / 2 + obj.Clearance,
-                0,
-            ),
+            fc.Vector(obj.xTotalWidth / 2 + obj.Clearance, obj.yTotalWidth / 2 + obj.Clearance, 0),
         )
 
         fuse_total = BinSolidMidSection.make(self, obj, bin_outside_shape)

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -55,9 +55,7 @@ class FoundationGridfinity:
             "version",
             "Gridfinity Workbench Version",
             1,
-        )
-
-        obj.version = __version__
+        ).version = __version__
 
     def execute(self, fp: Part.Feature) -> None:
         gridfinity_shape = self.generate_gridfinity_shape(fp)
@@ -70,7 +68,6 @@ class FoundationGridfinity:
             )  # ensure the bin is placed correctly before fusing
 
             result_shape = fp.BaseFeature.Shape.fuse(gridfinity_shape)
-
             result_shape.transformShape(fp.Placement.inverse().toMatrix(), copy=True)
 
             fp.Shape = result_shape
@@ -102,7 +99,7 @@ class BinBlank(FoundationGridfinity):
         """Create BinBlank object.
 
         Args:
-            obj (FreeCAD.DocumentObject): Document object
+            obj (FreeCAD.DocumentObject): Document object.
 
 
         """
@@ -173,25 +170,17 @@ class BinBlank(FoundationGridfinity):
         )
 
         fuse_total = BinSolidMidSection.make(self, obj, bin_outside_shape)
-
-        bin_base = make_complex_bin_base(obj, layout)
-
-        fuse_total = fuse_total.fuse(bin_base)
+        fuse_total = fuse_total.fuse(make_complex_bin_base(obj, layout))
 
         if obj.RecessedTopDepth > 0:
-            recessed_cut = BlankBinRecessedTop.make(self, obj, bin_inside_shape)
-
-            fuse_total = fuse_total.cut(recessed_cut)
+            fuse_total = fuse_total.cut(BlankBinRecessedTop.make(self, obj, bin_inside_shape))
 
         if obj.StackingLip:
-            stacking_lip = StackingLip.make(self, obj, bin_outside_shape)
-
-            fuse_total = fuse_total.fuse(stacking_lip)
+            fuse_total = fuse_total.fuse(StackingLip.make(self, obj, bin_outside_shape))
 
         if obj.ScrewHoles or obj.MagnetHoles:
-            holes = BinBottomHoles.make(self, obj, layout)
+            fuse_total = fuse_total.cut(BinBottomHoles.make(self, obj, layout))
 
-            fuse_total = Part.Shape.cut(fuse_total, holes)
         return fuse_total
 
 
@@ -256,25 +245,16 @@ class BinBase(FoundationGridfinity):
         )
 
         fuse_total = BinSolidMidSection.make(self, obj, bin_outside_shape)
-
-        bin_base = make_complex_bin_base(obj, layout)
-
-        fuse_total = fuse_total.fuse(bin_base)
+        fuse_total = fuse_total.fuse(make_complex_bin_base(obj, layout))
 
         if obj.RecessedTopDepth > 0:
-            recessed_cut = BlankBinRecessedTop.make(self, obj, bin_inside_shape)
-
-            fuse_total = fuse_total.cut(recessed_cut)
+            fuse_total = fuse_total.cut(BlankBinRecessedTop.make(self, obj, bin_inside_shape))
 
         if obj.StackingLip:
-            stacking_lip = StackingLip.make(self, obj, bin_outside_shape)
-
-            fuse_total = fuse_total.fuse(stacking_lip)
+            fuse_total = fuse_total.fuse(StackingLip.make(self, obj, bin_outside_shape))
 
         if obj.ScrewHoles or obj.MagnetHoles:
-            holes = BinBottomHoles.make(self, obj, layout)
-
-            fuse_total = Part.Shape.cut(fuse_total, holes)
+            fuse_total = fuse_total.cut(BinBottomHoles.make(self, obj, layout))
 
         return fuse_total
 
@@ -357,34 +337,20 @@ class SimpleStorageBin(FoundationGridfinity):
         )
 
         fuse_total = BinSolidMidSection.make(self, obj, bin_outside_shape)
-
-        bin_base = make_complex_bin_base(obj, layout)
-
-        fuse_total = fuse_total.fuse(bin_base)
-
-        compartements = Compartments.make(self, obj, bin_inside_shape)
-
-        fuse_total = fuse_total.cut(compartements)
+        fuse_total = fuse_total.fuse(make_complex_bin_base(obj, layout))
+        fuse_total = fuse_total.cut(Compartments.make(self, obj, bin_inside_shape))
 
         if obj.StackingLip:
-            stacking_lip = StackingLip.make(self, obj, bin_outside_shape)
-
-            fuse_total = fuse_total.fuse(stacking_lip)
+            fuse_total = fuse_total.fuse(StackingLip.make(self, obj, bin_outside_shape))
 
         if obj.ScrewHoles or obj.MagnetHoles:
-            holes = BinBottomHoles.make(self, obj, layout)
-
-            fuse_total = Part.Shape.cut(fuse_total, holes)
+            fuse_total = fuse_total.cut(BinBottomHoles.make(self, obj, layout))
 
         if obj.LabelShelfStyle != "Off":
-            label_shelf = LabelShelf.make(self, obj)
-
-            fuse_total = fuse_total.fuse(label_shelf)
+            fuse_total = fuse_total.fuse(LabelShelf.make(self, obj))
 
         if obj.Scoop:
-            scoop = Scoop.make(self, obj)
-
-            fuse_total = fuse_total.fuse(scoop)
+            fuse_total = fuse_total.fuse(Scoop.make(self, obj))
 
         return Part.Solid.removeSplitter(fuse_total)
 
@@ -465,28 +431,17 @@ class EcoBin(FoundationGridfinity):
         )
 
         fuse_total = BinSolidMidSection.make(self, obj, bin_outside_shape)
-
-        bin_base = make_complex_bin_base(obj, layout)
-
-        fuse_total = fuse_total.fuse(bin_base)
-
-        compartements = EcoCompartments.make(self, obj, layout, bin_inside_shape)
-
-        fuse_total = fuse_total.cut(compartements)
+        fuse_total = fuse_total.fuse(make_complex_bin_base(obj, layout))
+        fuse_total = fuse_total.cut(EcoCompartments.make(self, obj, layout, bin_inside_shape))
 
         if obj.ScrewHoles or obj.MagnetHoles:
-            holes = BinBottomHoles.make(self, obj, layout)
-
-            fuse_total = Part.Shape.cut(fuse_total, holes)
+            fuse_total = fuse_total.cut(BinBottomHoles.make(self, obj, layout))
 
         if obj.StackingLip:
-            stacking_lip = StackingLip.make(self, obj, bin_outside_shape)
-
-            fuse_total = fuse_total.fuse(stacking_lip)
+            fuse_total = fuse_total.fuse(StackingLip.make(self, obj, bin_outside_shape))
 
         if obj.LabelShelfStyle != "Off":
-            label_shelf = LabelShelf.make(self, obj)
-            fuse_total = fuse_total.fuse(label_shelf)
+            fuse_total = fuse_total.fuse(LabelShelf.make(self, obj))
 
         return Part.Solid.removeSplitter(fuse_total)
 
@@ -570,34 +525,20 @@ class PartsBin(FoundationGridfinity):
         )
 
         fuse_total = BinSolidMidSection.make(self, obj, bin_outside_shape)
-
-        bin_base = make_complex_bin_base(obj, layout)
-
-        fuse_total = fuse_total.fuse(bin_base)
-
-        compartements = Compartments.make(self, obj, bin_inside_shape)
-
-        fuse_total = fuse_total.cut(compartements)
+        fuse_total = fuse_total.fuse(make_complex_bin_base(obj, layout))
+        fuse_total = fuse_total.cut(Compartments.make(self, obj, bin_inside_shape))
 
         if obj.StackingLip:
-            stacking_lip = StackingLip.make(self, obj, bin_outside_shape)
-
-            fuse_total = fuse_total.fuse(stacking_lip)
+            fuse_total = fuse_total.fuse(StackingLip.make(self, obj, bin_outside_shape))
 
         if obj.ScrewHoles or obj.MagnetHoles:
-            holes = BinBottomHoles.make(self, obj, layout)
-
-            fuse_total = Part.Shape.cut(fuse_total, holes)
+            fuse_total = fuse_total.cut(BinBottomHoles.make(self, obj, layout))
 
         if obj.LabelShelfStyle != "Off":
-            label_shelf = LabelShelf.make(self, obj)
-
-            fuse_total = fuse_total.fuse(label_shelf)
+            fuse_total = fuse_total.fuse(LabelShelf.make(self, obj))
 
         if obj.Scoop:
-            scoop = Scoop.make(self, obj)
-
-            fuse_total = fuse_total.fuse(scoop)
+            fuse_total = fuse_total.fuse(Scoop.make(self, obj))
 
         return Part.Solid.removeSplitter(fuse_total)
 
@@ -649,13 +590,7 @@ class Baseplate(FoundationGridfinity):
             0,
             obj.BinOuterRadius,
         )
-        baseplate_outside_shape.translate(
-            fc.Vector(
-                obj.xTotalWidth / 2,
-                obj.yTotalWidth / 2,
-                0,
-            ),
-        )
+        baseplate_outside_shape.translate(fc.Vector(obj.xTotalWidth / 2, obj.yTotalWidth / 2, 0))
 
         solid_shape = BaseplateSolidShape.make(
             self,
@@ -665,15 +600,10 @@ class Baseplate(FoundationGridfinity):
         )
 
         fuse_total = make_complex_bin_base(obj, layout)
-        fuse_total.translate(
-            fc.Vector(
-                0,
-                0,
-                obj.TotalHeight,
-            ),
-        )
+        fuse_total.translate(fc.Vector(0, 0, obj.TotalHeight))
+        fuse_total = solid_shape.cut(fuse_total)
 
-        return Part.Shape.cut(solid_shape, fuse_total)
+        return fuse_total
 
 
 class MagnetBaseplate(FoundationGridfinity):
@@ -725,13 +655,7 @@ class MagnetBaseplate(FoundationGridfinity):
             -obj.MagnetHoleDepth - obj.MagnetBase,
             obj.BinOuterRadius,
         )
-        baseplate_outside_shape.translate(
-            fc.Vector(
-                obj.xTotalWidth / 2,
-                obj.yTotalWidth / 2,
-                0,
-            ),
-        )
+        baseplate_outside_shape.translate(fc.Vector(obj.xTotalWidth / 2, obj.yTotalWidth / 2, 0))
 
         solid_shape = BaseplateSolidShape.make(
             self,
@@ -741,23 +665,12 @@ class MagnetBaseplate(FoundationGridfinity):
         )
 
         fuse_total = make_complex_bin_base(obj, layout)
-        fuse_total.translate(
-            fc.Vector(
-                0,
-                0,
-                obj.TotalHeight,
-            ),
-        )
+        fuse_total.translate(fc.Vector(0, 0, obj.TotalHeight))
+        fuse_total = solid_shape.cut(fuse_total)
+        fuse_total = fuse_total.cut(BaseplateMagnetHoles.make(self, obj, layout))
+        fuse_total = fuse_total.cut(BaseplateCenterCut.make(self, obj, layout))
 
-        fuse_total = Part.Shape.cut(solid_shape, fuse_total)
-
-        magholes = BaseplateMagnetHoles.make(self, obj, layout)
-
-        fuse_total = Part.Shape.cut(fuse_total, magholes)
-
-        cutout = BaseplateCenterCut.make(self, obj, layout)
-
-        return Part.Shape.cut(fuse_total, cutout)
+        return fuse_total
 
 
 class ScrewTogetherBaseplate(FoundationGridfinity):
@@ -810,13 +723,7 @@ class ScrewTogetherBaseplate(FoundationGridfinity):
             -obj.BaseThickness,
             obj.BinOuterRadius,
         )
-        baseplate_outside_shape.translate(
-            fc.Vector(
-                obj.xTotalWidth / 2,
-                obj.yTotalWidth / 2,
-                0,
-            ),
-        )
+        baseplate_outside_shape.translate(fc.Vector(obj.xTotalWidth / 2, obj.yTotalWidth / 2, 0))
 
         solid_shape = BaseplateSolidShape.make(
             self,
@@ -826,31 +733,14 @@ class ScrewTogetherBaseplate(FoundationGridfinity):
         )
 
         fuse_total = make_complex_bin_base(obj, layout)
-        fuse_total.translate(
-            fc.Vector(
-                0,
-                0,
-                obj.TotalHeight,
-            ),
-        )
+        fuse_total.translate(fc.Vector(0, 0, obj.TotalHeight))
+        fuse_total = solid_shape.cut(fuse_total)
+        fuse_total = fuse_total.cut(BaseplateMagnetHoles.make(self, obj, layout))
+        fuse_total = fuse_total.cut(BaseplateCenterCut.make(self, obj, layout))
+        fuse_total = fuse_total.cut(BaseplateScrewBottomChamfer.make(self, obj, layout))
+        fuse_total = fuse_total.cut(BaseplateConnectionHoles.make(self, obj))
 
-        fuse_total = Part.Shape.cut(solid_shape, fuse_total)
-
-        magholes = BaseplateMagnetHoles.make(self, obj, layout)
-
-        fuse_total = Part.Shape.cut(fuse_total, magholes)
-
-        cutout = BaseplateCenterCut.make(self, obj, layout)
-
-        fuse_total = fuse_total.cut(cutout)
-
-        magchamfer = BaseplateScrewBottomChamfer.make(self, obj, layout)
-
-        fuse_total = Part.Shape.cut(fuse_total, magchamfer)
-
-        conholes = BaseplateConnectionHoles.make(self, obj)
-
-        return Part.Shape.cut(fuse_total, conholes)
+        return fuse_total
 
 
 class LBinBlank(FoundationGridfinity):
@@ -923,24 +813,15 @@ class LBinBlank(FoundationGridfinity):
         )
 
         fuse_total = BinSolidMidSection.make(self, obj, bin_outside_shape)
-
-        bin_base = make_complex_bin_base(obj, layout)
-
-        fuse_total = fuse_total.fuse(bin_base)
+        fuse_total = fuse_total.fuse(make_complex_bin_base(obj, layout))
 
         if obj.RecessedTopDepth > 0:
-            recessed_cut = BlankBinRecessedTop.make(self, obj, bin_inside_shape)
-
-            fuse_total = fuse_total.cut(recessed_cut)
+            fuse_total = fuse_total.cut(BlankBinRecessedTop.make(self, obj, bin_inside_shape))
 
         if obj.StackingLip:
-            stacking_lip = StackingLip.make(self, obj, bin_outside_shape)
-
-            fuse_total = fuse_total.fuse(stacking_lip)
+            fuse_total = fuse_total.fuse(StackingLip.make(self, obj, bin_outside_shape))
 
         if obj.ScrewHoles or obj.MagnetHoles:
-            holes = BinBottomHoles.make(self, obj, layout)
-
-            fuse_total = Part.Shape.cut(fuse_total, holes)
+            fuse_total = fuse_total.cut(BinBottomHoles.make(self, obj, layout))
 
         return fuse_total

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -352,7 +352,7 @@ class SimpleStorageBin(FoundationGridfinity):
         if obj.Scoop:
             fuse_total = fuse_total.fuse(Scoop.make(self, obj))
 
-        return Part.Solid.removeSplitter(fuse_total)
+        return fuse_total.removeSplitter()
 
 
 class EcoBin(FoundationGridfinity):
@@ -443,7 +443,7 @@ class EcoBin(FoundationGridfinity):
         if obj.LabelShelfStyle != "Off":
             fuse_total = fuse_total.fuse(LabelShelf.make(self, obj))
 
-        return Part.Solid.removeSplitter(fuse_total)
+        return fuse_total.removeSplitter()
 
 
 class PartsBin(FoundationGridfinity):
@@ -540,7 +540,7 @@ class PartsBin(FoundationGridfinity):
         if obj.Scoop:
             fuse_total = fuse_total.fuse(Scoop.make(self, obj))
 
-        return Part.Solid.removeSplitter(fuse_total)
+        return fuse_total.removeSplitter()
 
 
 class Baseplate(FoundationGridfinity):

--- a/freecad/gridfinity_workbench/grid_initial_layout.py
+++ b/freecad/gridfinity_workbench/grid_initial_layout.py
@@ -14,9 +14,7 @@ def _universal_properties(obj: fc.DocumentObject) -> None:
         "GenerationLocation",
         "Gridfinity",
         "Location of the bin. Change depending on how you want to customize",
-    )
-
-    obj.GenerationLocation = ["Positive from Origin", "Centered at Origin"]
+    ).GenerationLocation = ["Positive from Origin", "Centered at Origin"]
 
     obj.addProperty(
         "App::PropertyLength",
@@ -134,13 +132,11 @@ class RectangleLayout(utils.Feature):
         if obj.Baseplate:
             obj.xTotalWidth = obj.xGridUnits * obj.xGridSize
             obj.yTotalWidth = obj.yGridUnits * obj.yGridSize
-
         else:
             obj.xTotalWidth = obj.xGridUnits * obj.xGridSize - obj.Clearance * 2
             obj.yTotalWidth = obj.yGridUnits * obj.yGridSize - obj.Clearance * 2
 
         obj.xMaxGrids = obj.xGridUnits
-
         obj.yMaxGrids = obj.yGridUnits
 
         if obj.GenerationLocation == "Centered at Origin":
@@ -161,7 +157,7 @@ class LShapedLayout(utils.Feature):
 
         Args:
             obj (FreeCAD.DocumentObject): Document object.
-            baseplate_default (bool): is the object a baseplate
+            baseplate_default (bool): Whether the object is a baseplate or not.
 
         """
         _universal_properties(obj)
@@ -228,7 +224,6 @@ class LShapedLayout(utils.Feature):
             "Flags",
             "Is the Gridfinity Object a baseplate",
         ).Baseplate = baseplate_default
-
         obj.setEditorMode("Baseplate", 2)
 
     def make(self, obj: fc.DocumentObject) -> None:
@@ -246,7 +241,6 @@ class LShapedLayout(utils.Feature):
         if obj.x2GridUnits >= obj.x1GridUnits:
             obj.x2GridUnits = obj.x1GridUnits - 1
             fc.Console.PrintWarning("x2 Grid Units must be less than x1")
-
         if obj.y2GridUnits >= obj.y1GridUnits:
             obj.y2GridUnits = obj.y1GridUnits - 1
             fc.Console.PrintWarning("y2 Grid Units must be less than y1")
@@ -261,7 +255,6 @@ class LShapedLayout(utils.Feature):
 
             obj.xTotalWidth = obj.x1GridUnits * obj.xGridSize
             obj.yTotalWidth = obj.y1GridUnits * obj.yGridSize
-
         else:
             obj.x1TotalDimension = obj.x1GridUnits * obj.xGridSize - obj.Clearance * 2
             obj.y1TotalDimension = obj.y1GridUnits * obj.yGridSize - obj.Clearance * 2
@@ -272,7 +265,6 @@ class LShapedLayout(utils.Feature):
             obj.yTotalWidth = obj.y1GridUnits * obj.yGridSize - obj.Clearance * 2
 
         obj.xMaxGrids = obj.x1GridUnits
-
         obj.yMaxGrids = obj.y1GridUnits
 
         if obj.GenerationLocation == "Centered at Origin":
@@ -283,13 +275,7 @@ class LShapedLayout(utils.Feature):
             obj.yLocationOffset = 0
 
         ## L layout matrix creation
-        layout = [[False for y in range(obj.y1GridUnits)] for x in range(obj.x1GridUnits)]
-
-        for x in range(obj.x1GridUnits):
-            for y in range(obj.y1GridUnits):
-                if x < obj.x2GridUnits:
-                    layout[x][y] = True
-                if y < obj.y2GridUnits:
-                    layout[x][y] = True
-
-        return layout
+        return [
+            [x < obj.x2GridUnits or y < obj.y2GridUnits for y in range(obj.y1GridUnits)]
+            for x in range(obj.x1GridUnits)
+        ]

--- a/freecad/gridfinity_workbench/utils.py
+++ b/freecad/gridfinity_workbench/utils.py
@@ -269,24 +269,24 @@ def create_rounded_l(
     arc6x = arc1x
     arc6y = yoffset + radius - radius * math.sin(math.pi / 4)
 
-    l1v1 = fc.Vector(l1x, l1y1, 0)
-    l1v2 = fc.Vector(l1x, l1y2, 0)
-    arc1v = fc.Vector(arc1x, arc1y, 0)
-    l2v1 = fc.Vector(l2x1, l2y, 0)
-    l2v2 = fc.Vector(l2x2, l2y, 0)
-    arc2v = fc.Vector(arc2x, arc2y, 0)
-    l3v1 = fc.Vector(l3x, l3y1, 0)
-    l3v2 = fc.Vector(l3x, l3y2, 0)
-    arc3v = fc.Vector(arc3x, arc3y, 0)
-    l4v1 = fc.Vector(l4x1, l4y, 0)
-    l4v2 = fc.Vector(l4x2, l4y, 0)
-    arc4v = fc.Vector(arc4x, arc4y, 0)
-    l5v1 = fc.Vector(l5x, lsy1, 0)
-    l5v2 = fc.Vector(l5x, l5y2, 0)
-    arc5v = fc.Vector(arc5x, arc5y, 0)
-    l6v1 = fc.Vector(l6x1, l6y, 0)
-    l6v2 = fc.Vector(l6x2, l6y, 0)
-    arc6v = fc.Vector(arc6x, arc6y, 0)
+    l1v1 = fc.Vector(l1x, l1y1)
+    l1v2 = fc.Vector(l1x, l1y2)
+    arc1v = fc.Vector(arc1x, arc1y)
+    l2v1 = fc.Vector(l2x1, l2y)
+    l2v2 = fc.Vector(l2x2, l2y)
+    arc2v = fc.Vector(arc2x, arc2y)
+    l3v1 = fc.Vector(l3x, l3y1)
+    l3v2 = fc.Vector(l3x, l3y2)
+    arc3v = fc.Vector(arc3x, arc3y)
+    l4v1 = fc.Vector(l4x1, l4y)
+    l4v2 = fc.Vector(l4x2, l4y)
+    arc4v = fc.Vector(arc4x, arc4y)
+    l5v1 = fc.Vector(l5x, lsy1)
+    l5v2 = fc.Vector(l5x, l5y2)
+    arc5v = fc.Vector(arc5x, arc5y)
+    l6v1 = fc.Vector(l6x1, l6y)
+    l6v2 = fc.Vector(l6x2, l6y)
+    arc6v = fc.Vector(arc6x, arc6y)
 
     lines = [
         Part.LineSegment(l1v1, l1v2),
@@ -328,3 +328,25 @@ def rounded_l_extrude(
     """
     w1 = create_rounded_l(shape_data, xoffset, yoffset, radius)
     return Part.Face(w1).extrude(fc.Vector(0, 0, height))
+
+
+def multi_fuse(lst: list[Part.Shape]) -> Part.Shape:
+    """Fuses all shapes in the list into a single shape."""
+    if not lst:
+        raise ValueError("The list is empty")
+    return lst[0].multiFuse(lst[1:])
+
+
+def loop(lst: list[fc.Vector]) -> list[Part.LineSegment]:
+    """Get a closed loop consisting of LineSegments from consecutive points."""
+    if len(lst) < 3:
+        raise ValueError("List has to be of length at least 3")
+    return [Part.LineSegment(p1, p2) for p1, p2 in zip(lst, lst[1:] + lst[:1])]
+
+
+def corners(x: float, y: float, z: float=0) -> list[fc.Vector]:
+    """Get a list of four points located at (±x, ±y, z)."""
+    return [
+        fc.Vector(x_pos, y_pos, z)
+        for x_pos, y_pos in ((-x, -y), (x, -y), (-x, y), (x, y))
+    ]

--- a/freecad/gridfinity_workbench/utils.py
+++ b/freecad/gridfinity_workbench/utils.py
@@ -29,11 +29,11 @@ def copy_and_translate(shape: Part.Shape, vec_list: list[fc.Vector]) -> Part.Sha
 
     Args:
         shape (Part.Shape): Shape to copy.
-        vec_list (list[FreeCAD.Vector]): List of vectors wher the copies should be translated
+        vec_list (list[FreeCAD.Vector]): List of vectors where the copies should be translated
             to.
 
     Raises:
-        ValueError: List is empty
+        ValueError: List is empty.
         RuntimeError: Nothing copied.
 
     Returns:
@@ -41,8 +41,7 @@ def copy_and_translate(shape: Part.Shape, vec_list: list[fc.Vector]) -> Part.Sha
 
     """
     if not vec_list:
-        msg = "Vector list is empty"
-        raise ValueError(msg)
+        raise ValueError("Vector list is empty")
 
     final_shape: Part.Shape | None = None
     for vec in vec_list:
@@ -51,8 +50,7 @@ def copy_and_translate(shape: Part.Shape, vec_list: list[fc.Vector]) -> Part.Sha
         final_shape = tmp if final_shape is None else final_shape.fuse(tmp)
 
     if final_shape is None:
-        msg = "Nothing has been copied"
-        raise RuntimeError(msg)
+        raise RuntimeError("Nothing has been copied")
 
     return final_shape
 
@@ -67,12 +65,11 @@ def curve_to_wire(list_of_items: list[Part.LineSegment]) -> Part.Wire:
         list_of_items (list[Part.LineSegment]): List of items to convert in a wire.
 
     Returns:
-        Part.Wire: The created wire
+        Part.Wire: The created wire.
 
     """
     if not list_of_items:
-        msg = "List is empty"
-        raise ValueError(msg)
+        raise ValueError("List is empty")
 
     return Part.Wire([item.toShape() for item in list_of_items])
 
@@ -96,11 +93,9 @@ def create_rounded_rectangle(
 
     """
     if radius <= 0:
-        msg = "Radius should be > 0"
-        raise ValueError(msg)
+        raise ValueError("Radius should be > 0")
     if radius >= xwidth / 2 or radius >= ywidth / 2:
-        msg = "Radius should be smaller than xwidth /2 or ywidth / 2"
-        raise ValueError(msg)
+        raise ValueError("Radius should be smaller than xwidth/2 and ywidth/2")
 
     xfarv = xwidth / 2
     yfarv = ywidth / 2
@@ -171,8 +166,7 @@ def rounded_rectangle_chamfer(
         zsketchplane + height,
         radius + height,
     )
-    wires = [w1, w2]
-    return Part.makeLoft(wires, solid=True)
+    return Part.makeLoft([w1, w2], solid=True)
 
 
 def rounded_rectangle_extrude(
@@ -196,8 +190,7 @@ def rounded_rectangle_extrude(
 
     """
     w1 = create_rounded_rectangle(xwidth, ywidth, zsketchplane, radius)
-    face = Part.Face(w1)
-    return face.extrude(fc.Vector(0, 0, height))
+    return Part.Face(w1).extrude(fc.Vector(0, 0, height))
 
 
 @dataclass
@@ -205,13 +198,13 @@ class LShapeData:
     """Data class containing information regarding a L shape.
 
     L shape side names:
-      c
-    ┌───┐
-    │   │d
-    │   └──────┐
-    │          │b
-    └──────────┘
-         a
+        x2
+      ┌───┐
+      │   │
+    y1│   └──────┐
+      │          │ y2
+      └──────────┘
+           x1
     """
 
     x1: float
@@ -230,8 +223,8 @@ def create_rounded_l(
 
     Args:
         shape_data (LShapeData): Size data for the L shape.
-        xoffset (float): Offest in the X direction
-        yoffset (float): Offset in the Y direction
+        xoffset (float): Offest in the X direction.
+        yoffset (float): Offset in the Y direction.
         radius (float): Radius of the corners.
 
     Returns:
@@ -334,5 +327,4 @@ def rounded_l_extrude(
 
     """
     w1 = create_rounded_l(shape_data, xoffset, yoffset, radius)
-    face = Part.Face(w1)
-    return face.extrude(fc.Vector(0, 0, height))
+    return Part.Face(w1).extrude(fc.Vector(0, 0, height))

--- a/freecad/gridfinity_workbench/utils.py
+++ b/freecad/gridfinity_workbench/utils.py
@@ -339,14 +339,11 @@ def multi_fuse(lst: list[Part.Shape]) -> Part.Shape:
 
 def loop(lst: list[fc.Vector]) -> list[Part.LineSegment]:
     """Get a closed loop consisting of LineSegments from consecutive points."""
-    if len(lst) < 3:
+    if len(lst) < 3:  # noqa: PLR2004
         raise ValueError("List has to be of length at least 3")
     return [Part.LineSegment(p1, p2) for p1, p2 in zip(lst, lst[1:] + lst[:1])]
 
 
-def corners(x: float, y: float, z: float=0) -> list[fc.Vector]:
+def corners(x: float, y: float, z: float = 0) -> list[fc.Vector]:
     """Get a list of four points located at (±x, ±y, z)."""
-    return [
-        fc.Vector(x_pos, y_pos, z)
-        for x_pos, y_pos in ((-x, -y), (x, -y), (-x, y), (x, y))
-    ]
+    return [fc.Vector(x_pos, y_pos, z) for x_pos, y_pos in ((-x, -y), (x, -y), (-x, y), (x, y))]

--- a/freecad/gridfinity_workbench/version.py
+++ b/freecad/gridfinity_workbench/version.py
@@ -1,3 +1,3 @@
 """Module containing version information."""
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"

--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
 
   <description>This Workbench will generate several variations of parametric Gridfinity bins and baseplates that can be easily customized. </description>
 
-  <version>0.9.1</version>
+  <version>0.9.2</version>
 
   <date>2025-01-09</date>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,11 @@ version = "0.9.1"
 dev = ["ruff", "freecad-stubs"]
 
 [tool.ruff]
-select = ["ALL"]
 line-length = 100
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = ["EM101", "EM102", "RET504", "TRY003"]
 
 [tool.ruff.lint.per-file-ignores]
 # Ignore folowing rules for tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ py-modules = []
 
 [project]
 name = "gridfinityworkbench"
-version = "0.9.1"
+version = "0.9.2"
 
 [project.optional-dependencies]
 dev = ["ruff", "freecad-stubs"]


### PR DESCRIPTION
This PR is mostly aesthetics, I tried to not touch any logic.

### `fuse_total.cut(...)` vs `Part.Shape.cut(fuse_total, ...)`

Is there a reason that `fuse_total.cut(...)` is used in some places and `Part.Shape.cut(fuse_total, ...)` in others? I kept every call as is, but if they can be used interchangeably, I think it would be beneficial to unify them (at least locally).

### `_eco_bin_cut_fillet_edges_filter`

This function is unused (at least that is what my editor tells me). Can we remove it?

### Inlining

I inlined a lot of variables that were only used once in the next line. Extracting an argument into a variable is sometimes done if the name brings something new into the context (it is basically a comment then), or the argument is so complex that it makes the code unreadable. In the case when the variable name is basically the same as the function/object you call/create (and the call/creation is simple), I prefer just inlining it.

Doing so allows for really nice blocks of code like this:

```
fuse_total = make_complex_bin_base(obj, layout)
fuse_total.translate(FreeCAD.Vector(0, 0, obj.TotalHeight))
fuse_total = Part.Shape.cut(solid_shape, fuse_total)
fuse_total = Part.Shape.cut(fuse_total, BaseplateMagnetHoles.make(self, obj, layout))
fuse_total = Part.Shape.cut(fuse_total, BaseplateCenterCut.make(self, obj, layout))
```

Where it is *so easy* to see the big picture of what is going on:
1. First, we make a bin base
2. Then we translate it
3. Then we cut it out from a solid shape
4. From what is left we cut out magnet holes
5. And the center section

Everything is nicely aligned and close to each other, so you have all the context you need to understand what is going on in just these five lines of code.

### Vertical spaces

I also added/removed vertical blank lines when I thought it makes sense. Vertical spaces should be used to separate steps of the algorithm, and similar operations in the same step are better kept close.

### The `*`

I'd like to note the syntax of [c2, c3, c4, *ch], as the * in Python can sometimes be confusing. In this context (when you put a * in front of a list, tuple, etc) it expands the list to a comma separated arguments. For example:

```
l = [2, 'foo', 3]
l2 = [1, *l, 4]          # this
l2 = [1, 2, 'foo', 3, 4] # is equivalent to this
```

### My disagreement with Ruff

#### [EM101](https://docs.astral.sh/ruff/rules/raw-string-in-exception/), [EM102](https://docs.astral.sh/ruff/rules/f-string-in-exception/) and [TRY003](https://docs.astral.sh/ruff/rules/raise-vanilla-args/)

If you [search for `raise ValueError` in the numpy code](https://github.com/search?q=repo%3Anumpy%2Fnumpy+%22raise+ValueError%22&type=code) you always see passing a string literal to the exception constructor. The same is true for [scipy](https://github.com/search?q=repo%3Ascipy%2Fscipy%20raise%20ValueError&type=code), [pandas](https://github.com/search?q=repo%3Apandas-dev%2Fpandas%20raise%20ValueError&type=code), [matplotlib](https://github.com/search?q=repo%3Amatplotlib%2Fmatplotlib%20raise%20ValueError&type=code). These are some of the most used Python libraries. I have never see anyone doing what ruff suggest for the reason it brings.

It's true that it is not optimal to have this message duplicated, but that's life. You actually get used to seeing two of them (and the one from source code probably unformatted :) ). It's not a reason to write worse code.

I have disabled these rules in `pyproject.toml`.

#### [RET504](https://docs.astral.sh/ruff/rules/unnecessary-assign/)

It might not be necessary, but makes the code more readable, for example

```
fuse_total = make_complex_bin_base(obj, layout)
fuse_total.translate(FreeCAD.Vector(0, 0, obj.TotalHeight))
fuse_total = Part.Shape.cut(solid_shape, fuse_total)
fuse_total = fuse_total.cut(BaseplateMagnetHoles.make(self, obj, layout))
fuse_total = fuse_total.cut(BaseplateCenterCut.make(self, obj, layout))
fuse_total = fuse_total.cut(BaseplateScrewBottomChamfer.make(self, obj, layout))
fuse_total = fuse_total.cut(BaseplateConnectionHoles.make(self, obj))

return fuse_total
```

is much more readable than

```
fuse_total = make_complex_bin_base(obj, layout)
fuse_total.translate(FreeCAD.Vector(0, 0, obj.TotalHeight))
fuse_total = Part.Shape.cut(solid_shape, fuse_total)
fuse_total = fuse_total.cut(BaseplateMagnetHoles.make(self, obj, layout))
fuse_total = fuse_total.cut(BaseplateCenterCut.make(self, obj, layout))
fuse_total = fuse_total.cut(BaseplateScrewBottomChamfer.make(self, obj, layout))
return fuse_total.cut(BaseplateConnectionHoles.make(self, obj))
```

I currently have mixed feelings about this rule. From one point of view, it makes sense to leave it enabled, and add `# noqa: RET504` where it makes the code more readable. From the other side, I think that the specificity of this project (where you often chain some operations one after another on the end of a function and return the result) makes not using it a default – and in 90% of times this rule fires you just get angry that a tool is too stupid to understand the context and add `noqa`, and it is a really bad developer experience.

I have disabled the rule, but if you disagree we can bring it back and add `noqa` where it makes sense.
