### PR TITLE
add fixed versions to dependecies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: ruudjhuu/freecad:v0.0.1
+    container: ruudjhuu/freecad:v1.0.0
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    container: ruudjhuu/freecad:v0.0.1
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Build docker images
-        run: docker build -t local - < tools/Dockerfile
       - name: Run tests
-        run: docker run -v $PWD:/srv -w/srv local python -m unittest discover tests -v
+        run: python -m unittest discover tests -v

--- a/freecad/gridfinity_workbench/version.py
+++ b/freecad/gridfinity_workbench/version.py
@@ -1,3 +1,3 @@
 """Module containing version information."""
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"

--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
 
   <description>This Workbench will generate several variations of parametric Gridfinity bins and baseplates that can be easily customized. </description>
 
-  <version>0.9.4</version>
+  <version>0.9.5</version>
 
   <date>2025-01-09</date>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "gridfinityworkbench"
 version = "0.9.4"
 
 [project.optional-dependencies]
-dev = ["ruff", "freecad-stubs"]
+dev = ["ruff==0.9.5", "freecad-stubs==1.0.18"]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ py-modules = []
 
 [project]
 name = "gridfinityworkbench"
-version = "0.9.4"
+version = "0.9.5"
 
 [project.optional-dependencies]
 dev = ["ruff==0.9.5", "freecad-stubs==1.0.18"]


### PR DESCRIPTION
fixes #72 

* Added fixed versions to dev dependencies.\
   It might be an idea to setup Dependabot to automatically manage dependency version updates.  [Quick Start](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide)
* Added fixed test runner image.
  I created a image on [dockerhub](https://hub.docker.com/r/ruudjhuu/freecad) of which the source is in https://github.com/Ruudjhuu/docker-freecad/. I added versioning to the image so we can update the testrunner in this repo when we want in a separate PR (not sure if dependabot support this one). I have the intention to update the image when new FreeCAD versions is released. 