### PR TITLE
Deduplicate code for label shelf creation

### DIFF
--- a/freecad/gridfinity_workbench/utils.py
+++ b/freecad/gridfinity_workbench/utils.py
@@ -41,10 +41,7 @@ def copy_and_translate(shape: Part.Shape, vec_list: list[fc.Vector]) -> Part.Sha
     """
     if not vec_list:
         raise ValueError("Vector list is empty")
-    return multi_fuse([
-        shape.translated(vec)
-        for vec in vec_list
-    ])
+    return multi_fuse([shape.translated(vec) for vec in vec_list])
 
 
 def curve_to_wire(list_of_items: list[Part.LineSegment]) -> Part.Wire:

--- a/freecad/gridfinity_workbench/utils.py
+++ b/freecad/gridfinity_workbench/utils.py
@@ -331,9 +331,16 @@ def rounded_l_extrude(
 
 
 def multi_fuse(lst: list[Part.Shape]) -> Part.Shape:
-    """Fuses all shapes in the list into a single shape."""
+    """Fuses all shapes in the list into a single shape.
+
+    Raises `ValueError` if the list is empty. If there is only one shape on the list, returns
+    a reference to that shape. Otherwise returns a new shape that is a fusion of all shapes from
+    the list.
+    """
     if not lst:
         raise ValueError("The list is empty")
+    if len(lst) == 1:
+        return lst[0]
     return lst[0].multiFuse(lst[1:])
 
 

--- a/freecad/gridfinity_workbench/utils.py
+++ b/freecad/gridfinity_workbench/utils.py
@@ -34,7 +34,6 @@ def copy_and_translate(shape: Part.Shape, vec_list: list[fc.Vector]) -> Part.Sha
 
     Raises:
         ValueError: List is empty.
-        RuntimeError: Nothing copied.
 
     Returns:
         Part.Shape: Shape consting of the copies in the locations specified by vec_list.
@@ -42,17 +41,10 @@ def copy_and_translate(shape: Part.Shape, vec_list: list[fc.Vector]) -> Part.Sha
     """
     if not vec_list:
         raise ValueError("Vector list is empty")
-
-    final_shape: Part.Shape | None = None
-    for vec in vec_list:
-        tmp = shape.copy()
-        tmp = tmp.translate(vec)
-        final_shape = tmp if final_shape is None else final_shape.fuse(tmp)
-
-    if final_shape is None:
-        raise RuntimeError("Nothing has been copied")
-
-    return final_shape
+    return multi_fuse([
+        shape.translated(vec)
+        for vec in vec_list
+    ])
 
 
 def curve_to_wire(list_of_items: list[Part.LineSegment]) -> Part.Wire:

--- a/tests/test_unit_utils.py
+++ b/tests/test_unit_utils.py
@@ -22,10 +22,7 @@ class UtilsTest(unittest.TestCase):
 
         utils.copy_and_translate(shape, vec_list)
 
-        self.assertEqual(2, shape.copy.call_count)
-        self.assertEqual(2, shape.copy.return_value.translate.call_count)
-        for vec in vec_list:
-            shape.copy.return_value.translate.assert_has_calls([mock.call(vec)])
+        self.assertEqual(2, shape.translated.call_count)
 
     def test_curve_to_wire_empty_list(self) -> None:
         self.assertRaises(ValueError, utils.curve_to_wire, [])


### PR DESCRIPTION
I wanted start making progress towards #76, so I started reading how label shelves are constructed. But I couldn't understand what is going on, so I refactored a bunch of code by merging common parts. I hope it is now more readable and maintanable.

I mainly moved the code around, without changing the steps of generation, with the exception of always cutting both fillets in two bin corners. It won't affect performance, but simplifies the code and adds robustness in some corner (heh) cases. For example a side attached shelf of length 81,5mm in a 2x2 box would not trigger the
```py
if obj.LabelShelfLength > ycompwidth:
    shelf_placement = "Full Width"
```
but still is partially outside the bin:
![image](https://github.com/user-attachments/assets/124cfd7a-783d-4768-b5ec-99ed7889007f)
