### PR TITLE
Refactor label shelf creation

### DIFF
--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -116,6 +116,7 @@ class LabelShelf(utils.Feature):
         shelf_angle = obj.LabelShelfAngle.Value
         if obj.LabelShelfStyle == "Overhang":
             shelf_angle = 0
+            shelf_placement = "Full Width"
 
         length = obj.LabelShelfLength
         if shelf_placement == "Full Width":

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -113,16 +113,14 @@ class LabelShelf(utils.Feature):
             obj.LabelShelfPlacement if obj.LabelShelfLength <= ycompwidth else "Full Width"
         )
 
+        shelf_angle = obj.LabelShelfAngle.Value
+        if obj.LabelShelfStyle == "Overhang":
+            shelf_angle = 0
+
         length = obj.LabelShelfLength
         if shelf_placement == "Full Width":
             ydiv = 1
             length = obj.yTotalWidth - obj.WallThickness * 2
-
-        shelf_angle = obj.LabelShelfAngle.Value
-
-        if obj.LabelShelfStyle == "Overhang":
-            shelf_angle = 0
-            shelf_placement = "Full Width"
 
         width = (
             obj.StackingLipTopChamfer

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -131,17 +131,14 @@ class LabelShelf(utils.Feature):
         )
         assert width >= 0
 
-        side_a = width
-        side_c = side_a / math.sin(math.radians(90 - shelf_angle))
-        side_b = math.sqrt(side_c**2 - side_a**2)
         thickness = obj.LabelShelfVerticalThickness
-        height = thickness + side_b * unitmm
+        height = thickness + math.tan(math.radians(shelf_angle)) * width
 
-        funcfuse = label_shelf.label_shelf(
+        funcfuse = label_shelf.from_dimensions(
             length=length,
             width=width,
-            height=height,
             thickness=thickness,
+            height=height,
         )
 
         if height > obj.UsableHeight:

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -33,9 +33,7 @@ class LabelShelf(utils.Feature):
             "LabelShelfStyle",
             "Gridfinity",
             "Choose to have the label shelf Off or a Standard or Overhang style",
-        )
-
-        obj.LabelShelfStyle = ["Off", "Standard", "Overhang"]
+        ).LabelShelfStyle = ["Off", "Standard", "Overhang"]
         obj.LabelShelfStyle = label_style_default
 
         obj.addProperty(
@@ -43,9 +41,7 @@ class LabelShelf(utils.Feature):
             "LabelShelfPlacement",
             "Gridfinity",
             "Choose the Placement of the label shelf for each compartement",
-        )
-
-        obj.LabelShelfPlacement = ["Center", "Full Width", "Left", "Right"]
+        ).LabelShelfPlacement = ["Center", "Full Width", "Left", "Right"]
 
         ## Gridfinity Non Standard Parameters
         obj.addProperty(
@@ -102,22 +98,20 @@ class LabelShelf(utils.Feature):
             and obj.LabelShelfStyle != "Overhang"
         ):
             obj.LabelShelfStyle = "Overhang"
-            fc.Console.PrintWarning(
-                "Label shelf style set to Overhang due to low bin height\n",
-            )
+            fc.Console.PrintWarning("Label shelf style set to Overhang due to low bin height\n")
 
         xdiv = obj.xDividers + 1
         ydiv = obj.yDividers + 1
         xcompwidth = (
             obj.xTotalWidth - obj.WallThickness * 2 - obj.DividerThickness * obj.xDividers
-        ) / (xdiv)
+        ) / xdiv
         ycompwidth = (
             obj.yTotalWidth - obj.WallThickness * 2 - obj.DividerThickness * obj.yDividers
-        ) / (ydiv)
+        ) / ydiv
 
-        shelf_placement = obj.LabelShelfPlacement
-        if obj.LabelShelfLength > ycompwidth:
-            shelf_placement = "Full Width"
+        shelf_placement = (
+            obj.LabelShelfPlacement if obj.LabelShelfLength <= ycompwidth else "Full Width"
+        )
 
         length = obj.LabelShelfLength
         if shelf_placement == "Full Width":
@@ -153,12 +147,7 @@ class LabelShelf(utils.Feature):
         )
 
         if height > obj.UsableHeight:
-            boundingbox = Part.makeBox(
-                width,
-                length,
-                height,
-                fc.Vector(0, 0, -obj.UsableHeight),
-            )
+            boundingbox = Part.makeBox(width, length, height, fc.Vector(0, 0, -obj.UsableHeight))
             funcfuse = funcfuse.common(boundingbox)
 
         funcfuse = utils.copy_in_grid(

--- a/freecad/gridfinity_workbench/label_shelf.py
+++ b/freecad/gridfinity_workbench/label_shelf.py
@@ -50,20 +50,20 @@ def outside_fillet(
     return shape
 
 
-def label_shelf(
+def from_dimensions(
     *,
     length: fc.Units.Quantity,
     width: fc.Units.Quantity,
-    height: fc.Units.Quantity,
     thickness: fc.Units.Quantity,
+    height: fc.Units.Quantity,
 ) -> Part.Shape:
     """Create a label shelf with given dimensions.
 
     Args:
         length: Total length of the shelf.
         width: Total width of the shelf.
-        height: Height of the back of the shelf.
         thickness: Height of the front of the shelf.
+        height: Height of the back of the shelf.
 
     """
     v = [
@@ -89,3 +89,27 @@ def label_shelf(
     shape = shape.makeFillet(thickness.Value - 0.01, h_edges)
 
     return shape
+
+
+def from_angle(
+    *,
+    length: fc.Units.Quantity,
+    width: fc.Units.Quantity,
+    thickness: fc.Units.Quantity,
+    angle: fc.Units.Angle,
+) -> Part.Shape:
+    """Create a label shelf with given width and angle.
+
+    Args:
+        length: Total length of the shelf.
+        width: Total width of the shelf.
+        thickness: Height of the front of the shelf.
+        angle: Angle of the shelf.
+
+    """
+    return from_dimensions(
+        length=length,
+        width=width,
+        thickness=thickness,
+        height=thickness + math.tan(angle.Value) * width,
+    )

--- a/freecad/gridfinity_workbench/label_shelf.py
+++ b/freecad/gridfinity_workbench/label_shelf.py
@@ -1,0 +1,105 @@
+"""A module for making label shelves."""
+
+import math
+
+import FreeCAD as fc  # noqa: N813
+import Part
+
+from . import utils
+
+unitmm = fc.Units.Quantity("1 mm")
+
+
+def _front_fillet(
+    shape: Part.Shape,
+    thickness: fc.Units.Quantity,
+    tolabelend: float,
+) -> Part.Shape:
+    def fillet_point(p: Part.Point) -> bool:
+        return p.z == -thickness and p.x == tolabelend
+
+    h_edges = [
+        edge
+        for edge in shape.Edges
+        if fillet_point(edge.Vertexes[0].Point) and fillet_point(edge.Vertexes[1].Point)
+    ]
+    assert h_edges
+
+    return shape.makeFillet(thickness.Value - 0.01, h_edges)
+
+
+def _corner_fillet(radius: float) -> Part.Face:
+    arc1 = radius - radius * math.sin(math.pi / 4)
+
+    l1v1 = fc.Vector(0, 0)
+    l1v2 = fc.Vector(0, radius)
+    arc1v = fc.Vector(arc1, arc1)
+    l2v1 = fc.Vector(radius, 0)
+    l2v2 = fc.Vector(0, 0)
+
+    lines = [
+        Part.LineSegment(l1v1, l1v2),
+        Part.Arc(l1v2, arc1v, l2v1),
+        Part.LineSegment(l2v1, l2v2),
+    ]
+
+    return Part.Face(utils.curve_to_wire(lines))
+
+
+def outside_fillet(
+    shape: Part.Shape,
+    *,
+    offset: float,
+    radius: float,
+    height: float,
+    y_width: float,
+) -> Part.Shape:
+    """Fillets a label shelves corners that stick out from bins corners."""
+    right_end_fillet = _corner_fillet(radius)
+    right_end_fillet.rotate(fc.Vector(0, 0, 0), fc.Vector(0, 0, 1), -90)
+    right_end_fillet.translate(
+        fc.Vector(offset, y_width),
+    )
+    right_end_fillet = right_end_fillet.extrude(
+        fc.Vector(0, 0, -height),
+    )
+    shape = shape.cut(right_end_fillet)
+
+    left_end_fillet = _corner_fillet(radius)
+    left_end_fillet.translate(fc.Vector(offset, offset))
+    left_end_fillet = left_end_fillet.extrude(
+        fc.Vector(0, 0, -height),
+    )
+    shape = shape.cut(left_end_fillet)
+
+    return shape
+
+
+def label_shelf(
+    *,
+    length: fc.Units.Quantity,
+    width: fc.Units.Quantity,
+    height: fc.Units.Quantity,
+    thickness: fc.Units.Quantity,
+) -> Part.Shape:
+    """Create a label shelf with given dimensions.
+
+    Args:
+        length: Total length of the shelf.
+        width: Total width of the shelf.
+        height: Height of the back of the shelf.
+        thickness: Height of the front of the shelf.
+
+    """
+    v = [
+        fc.Vector(0, 0, 0),
+        fc.Vector(width, 0, 0),
+        fc.Vector(width, 0, -thickness),
+        fc.Vector(0, 0, -height),
+    ]
+
+    face = Part.Face(utils.curve_to_wire(utils.loop(v)))
+    shape = face.extrude(fc.Vector(0, length))
+    shape = _front_fillet(shape, thickness, width)
+
+    return shape

--- a/freecad/gridfinity_workbench/label_shelf.py
+++ b/freecad/gridfinity_workbench/label_shelf.py
@@ -79,6 +79,7 @@ def label_shelf(
     # Front fillet
     def fillet_point(p: Part.Point) -> bool:
         return p.z == -thickness and p.x == width
+
     h_edges = [
         edge
         for edge in shape.Edges

--- a/freecad/gridfinity_workbench/label_shelf.py
+++ b/freecad/gridfinity_workbench/label_shelf.py
@@ -10,24 +10,6 @@ from . import utils
 unitmm = fc.Units.Quantity("1 mm")
 
 
-def _front_fillet(
-    shape: Part.Shape,
-    thickness: fc.Units.Quantity,
-    width: float,
-) -> Part.Shape:
-    def fillet_point(p: Part.Point) -> bool:
-        return p.z == -thickness and p.x == width
-
-    h_edges = [
-        edge
-        for edge in shape.Edges
-        if fillet_point(edge.Vertexes[0].Point) and fillet_point(edge.Vertexes[1].Point)
-    ]
-    assert h_edges
-
-    return shape.makeFillet(thickness.Value - 0.01, h_edges)
-
-
 def _corner_fillet(radius: float) -> Part.Face:
     arc = radius - radius * math.sin(math.pi / 4)
 
@@ -93,6 +75,16 @@ def label_shelf(
 
     face = Part.Face(utils.curve_to_wire(utils.loop(v)))
     shape = face.extrude(fc.Vector(0, length))
-    shape = _front_fillet(shape, thickness, width)
+
+    # Front fillet
+    def fillet_point(p: Part.Point) -> bool:
+        return p.z == -thickness and p.x == width
+    h_edges = [
+        edge
+        for edge in shape.Edges
+        if fillet_point(edge.Vertexes[0].Point) and fillet_point(edge.Vertexes[1].Point)
+    ]
+    assert h_edges
+    shape = shape.makeFillet(thickness.Value - 0.01, h_edges)
 
     return shape

--- a/freecad/gridfinity_workbench/utils.py
+++ b/freecad/gridfinity_workbench/utils.py
@@ -41,10 +41,7 @@ def copy_and_translate(shape: Part.Shape, vec_list: list[fc.Vector]) -> Part.Sha
     """
     if not vec_list:
         raise ValueError("Vector list is empty")
-    return multi_fuse([
-        shape.translated(vec)
-        for vec in vec_list
-    ])
+    return multi_fuse([shape.translated(vec) for vec in vec_list])
 
 
 def curve_to_wire(list_of_items: list[Part.LineSegment]) -> Part.Wire:

--- a/freecad/gridfinity_workbench/utils.py
+++ b/freecad/gridfinity_workbench/utils.py
@@ -331,9 +331,16 @@ def rounded_l_extrude(
 
 
 def multi_fuse(lst: list[Part.Shape]) -> Part.Shape:
-    """Fuses all shapes in the list into a single shape."""
+    """Fuses all shapes in the list into a single shape.
+
+    Raises `ValueError` if the list is empty. If there is only one shape on the list, returns
+    a reference to that shape. Otherwise returns a new shape that is a fusion of all shapes from
+    the list.
+    """
     if not lst:
         raise ValueError("The list is empty")
+    if len(lst) == 1:
+        return lst[0]
     return lst[0].multiFuse(lst[1:])
 
 

--- a/freecad/gridfinity_workbench/utils.py
+++ b/freecad/gridfinity_workbench/utils.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 import FreeCAD as fc  # noqa:N813
 import Part
 
+unitmm = fc.Units.Quantity("1 mm")
+
 
 class Feature:
     """Gloabal feature class."""
@@ -42,6 +44,23 @@ def copy_and_translate(shape: Part.Shape, vec_list: list[fc.Vector]) -> Part.Sha
     if not vec_list:
         raise ValueError("Vector list is empty")
     return multi_fuse([shape.translated(vec) for vec in vec_list])
+
+
+def copy_in_grid(
+    shape: Part.Shape,
+    *,
+    x_count: int,
+    y_count: int,
+    x_offset: float,
+    y_offset: float,
+) -> Part.Shape:
+    """Copy a shape in a grid layout."""
+    shapes = [
+        shape.translated(fc.Vector(x * x_offset * unitmm, y * y_offset * unitmm))
+        for x in range(x_count)
+        for y in range(y_count)
+    ]
+    return multi_fuse(shapes)
 
 
 def curve_to_wire(list_of_items: list[Part.LineSegment]) -> Part.Wire:

--- a/freecad/gridfinity_workbench/utils.py
+++ b/freecad/gridfinity_workbench/utils.py
@@ -34,7 +34,6 @@ def copy_and_translate(shape: Part.Shape, vec_list: list[fc.Vector]) -> Part.Sha
 
     Raises:
         ValueError: List is empty.
-        RuntimeError: Nothing copied.
 
     Returns:
         Part.Shape: Shape consting of the copies in the locations specified by vec_list.
@@ -42,17 +41,10 @@ def copy_and_translate(shape: Part.Shape, vec_list: list[fc.Vector]) -> Part.Sha
     """
     if not vec_list:
         raise ValueError("Vector list is empty")
-
-    final_shape: Part.Shape | None = None
-    for vec in vec_list:
-        tmp = shape.copy()
-        tmp = tmp.translate(vec)
-        final_shape = tmp if final_shape is None else final_shape.fuse(tmp)
-
-    if final_shape is None:
-        raise RuntimeError("Nothing has been copied")
-
-    return final_shape
+    return multi_fuse([
+        shape.translated(vec)
+        for vec in vec_list
+    ])
 
 
 def curve_to_wire(list_of_items: list[Part.LineSegment]) -> Part.Wire:

--- a/freecad/gridfinity_workbench/version.py
+++ b/freecad/gridfinity_workbench/version.py
@@ -1,3 +1,3 @@
 """Module containing version information."""
 
-__version__ = "0.9.5"
+__version__ = "0.9.6"

--- a/freecad/gridfinity_workbench/version.py
+++ b/freecad/gridfinity_workbench/version.py
@@ -1,3 +1,3 @@
 """Module containing version information."""
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"

--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
 
   <description>This Workbench will generate several variations of parametric Gridfinity bins and baseplates that can be easily customized. </description>
 
-  <version>0.9.5</version>
+  <version>0.9.6</version>
 
   <date>2025-02-23</date>
 

--- a/package.xml
+++ b/package.xml
@@ -5,9 +5,9 @@
 
   <description>This Workbench will generate several variations of parametric Gridfinity bins and baseplates that can be easily customized. </description>
 
-  <version>0.9.4</version>
+  <version>0.9.5</version>
 
-  <date>2025-01-09</date>
+  <date>2025-02-23</date>
 
   <license file="LICENSE">lgpl-2.1-or-later</license>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ py-modules = []
 
 [project]
 name = "gridfinityworkbench"
-version = "0.9.5"
+version = "0.9.6"
 
 [project.optional-dependencies]
 dev = ["ruff", "freecad-stubs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ py-modules = []
 
 [project]
 name = "gridfinityworkbench"
-version = "0.9.4"
+version = "0.9.5"
 
 [project.optional-dependencies]
 dev = ["ruff", "freecad-stubs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["EM101", "EM102", "RET504", "TRY003"]
+ignore = ["EM101", "EM102", "RET504", "TRY003", "S101"]
 
 [tool.ruff.lint.per-file-ignores]
 # Ignore folowing rules for tests:

--- a/tests/test_unit_utils.py
+++ b/tests/test_unit_utils.py
@@ -22,10 +22,7 @@ class UtilsTest(unittest.TestCase):
 
         utils.copy_and_translate(shape, vec_list)
 
-        self.assertEqual(2, shape.copy.call_count)
-        self.assertEqual(2, shape.copy.return_value.translate.call_count)
-        for vec in vec_list:
-            shape.copy.return_value.translate.assert_has_calls([mock.call(vec)])
+        self.assertEqual(2, shape.translated.call_count)
 
     def test_curve_to_wire_empty_list(self) -> None:
         self.assertRaises(ValueError, utils.curve_to_wire, [])


### PR DESCRIPTION
I wanted start making progress towards #76, so I started reading how label shelves are constructed. But I couldn't understand what is going on, so I refactored some parts of it. I hope it is now more readable and maintanable.

The main idea behind this refactor was:
- Deduplication of code.
- Working in local coordinate system whenever possible. This reduces the usage of many parameters in formulas, only doing a single translation in the end. This way the formulas are simpler and it's easier to grasp what is going on.
- Separating raw label shelf creation to a different file, so it can be used for #76.

Important changes in behavior in this PR:
- Reduced complexity by front-filleting before copying to each divider cell.
- This fixed a bug that caused only label shelves with x=0 to be front-filleted.
- Reduced complexity by cutting part of the shelf that is sticking out from the bottom before copying to each divider cell.
- Fixed a bug where in some cases label shelf would partially stick out of the bin in the corner.
- Allowed center/left/right placed overhang label shelves.