### PR TITLE
FreeCAD integrated tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,29 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  unit-tests:
     runs-on: ubuntu-latest
-    container: ruudjhuu/freecad:v1.0.0
+    container: ruudjhuu/freecad:v1.0.0-2
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Run tests
+      - name: Run unit tests
         run: python -m unittest discover tests -v
+  freecad-tests:
+    runs-on: ubuntu-latest
+    container: ruudjhuu/freecad:v1.0.0-2
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Add workbench to FreeCAD
+        run: |
+          mkdir -p $HOME/.local/share/FreeCAD/Mod
+          ln -s $PWD $HOME/.local/share/FreeCAD/Mod/Gridfinity
+      - name: Run freecad tests
+        run: |
+          set -o pipefail
+          xvfb-run freecad -t freecad.gridfinity_workbench.test_gridfinity 2>&1 | tee output.txt
+      - name: Check caught exceptions
+        # FreeCAD catches exceptions during command invocation and only shows them in GUI, exiting with 0
+        # This makes the some tests pass when they shouldn't, so we look for the exceptions here
+        run: "! grep -B 1 Traceback output.txt"

--- a/freecad/gridfinity_workbench/init_gui.py
+++ b/freecad/gridfinity_workbench/init_gui.py
@@ -115,3 +115,5 @@ class GridfinityWorkbench(Workbench):
 
 
 fcg.addWorkbench(GridfinityWorkbench())
+
+fc.__unit_test__ += ["freecad.gridfinity_workbench.test_gridfinity"]

--- a/freecad/gridfinity_workbench/test_gridfinity.py
+++ b/freecad/gridfinity_workbench/test_gridfinity.py
@@ -1,0 +1,197 @@
+import unittest
+from pathlib import Path
+from tempfile import gettempdir
+
+import FreeCAD as fc  # noqa: N813
+import FreeCADGui as fcg  # noqa: N813
+
+import freecad
+
+TEMPDIR = Path(gettempdir())
+DOC_NAME = "GridfinityDocument"
+
+SIMPLE_COMMANDS = [
+    "CreateBinBlank",
+    "CreateBinBase",
+    "CreateSimpleStorageBin",
+    "CreateEcoBin",
+    "CreatePartsBin",
+    "CreateBaseplate",
+    "CreateMagnetBaseplate",
+    "CreateScrewTogetherBaseplate",
+    "CreateLBinBlank",
+]
+
+CUSTOM_BIN_COMMANDS = [
+    "CreateCustomBlankBin",
+]
+
+
+fcg.activateWorkbench("GridfinityWorkbench")
+
+
+class TestWithDocument(unittest.TestCase):
+    """Base class for test that do everything on an open document.
+
+    If a test fails, the file can be found in temporary directory (/tmp on Linux).
+    """
+
+    def setUp(self) -> None:
+        self.doc = fc.newDocument(DOC_NAME)
+        self.filepath = f"{TEMPDIR / self.__class__.__name__!s}_{self._testMethodName}.FCStd"
+
+    def tearDown(self) -> None:
+        self.doc.saveAs(str(self.filepath))
+        fc.closeDocument(DOC_NAME)
+
+
+class TestCommands(unittest.TestCase):
+    def test_commands_active(self) -> None:
+        commands = SIMPLE_COMMANDS + CUSTOM_BIN_COMMANDS
+
+        for command_name in commands:
+            self.assertFalse(fcg.Command.get(command_name).isActive(), msg=command_name)
+
+        fc.newDocument(DOC_NAME)
+
+        for command_name in commands:
+            self.assertTrue(fcg.Command.get(command_name).isActive(), msg=command_name)
+
+        fc.closeDocument(DOC_NAME)
+
+
+class TestSave(unittest.TestCase):
+    def test_reopen(self) -> None:
+        filepath = str(TEMPDIR / self.__class__.__name__) + ".FCStd"
+        commands = SIMPLE_COMMANDS
+
+        doc = fc.newDocument(DOC_NAME)
+
+        for command_name in commands:
+            fcg.Command.get(command_name).run()
+        self.assertEqual(len(doc.Objects), len(commands))
+
+        doc.saveAs(str(filepath))
+        fc.closeDocument(doc.Name)
+
+        doc = fc.openDocument(filepath)
+
+        self.assertEqual(len(doc.Objects), len(commands))
+
+        # change something, so `recompute` is not optimized out
+        # (even force=True doesn't guarantee this)
+        for obj in doc.Objects:
+            obj.xGridSize = 30
+        recomputed_count = doc.recompute(None, True)  # noqa: FBT003
+        self.assertEqual(recomputed_count, len(commands))
+
+        doc.save()
+        fc.closeDocument(doc.Name)
+
+
+class TestGenerationLocation(TestWithDocument):
+    def setUp(self) -> None:
+        super().setUp()
+        self.commands = SIMPLE_COMMANDS.copy()
+        self.commands.remove("CreateLBinBlank")
+
+    def test_positive_from_origin(self) -> None:
+        for command_name in self.commands:
+            fcg.Command.get(command_name).run()
+            obj = fcg.ActiveDocument.ActiveObject.Object
+            if hasattr(obj, "LabelShelfStyle"):
+                obj.LabelShelfStyle = "Off"
+            if hasattr(obj, "Scoop"):
+                obj.Scoop = False
+            obj.recompute()
+            center = obj.Shape.CenterOfGravity
+            self.assertAlmostEqual(center.x, obj.xGridSize.Value, msg=command_name)
+            self.assertAlmostEqual(center.y, obj.yGridSize.Value, msg=command_name)
+
+    def test_centered_at_origin(self) -> None:
+        for command_name in self.commands:
+            fcg.Command.get(command_name).run()
+            obj = fcg.ActiveDocument.ActiveObject.Object
+            obj.GenerationLocation = "Centered at Origin"
+            if hasattr(obj, "LabelShelfStyle"):
+                obj.LabelShelfStyle = "Off"
+            if hasattr(obj, "Scoop"):
+                obj.Scoop = False
+            obj.recompute()
+            center = obj.Shape.CenterOfGravity
+            self.assertAlmostEqual(center.x, 0, msg=command_name)
+            self.assertAlmostEqual(center.y, 0, msg=command_name)
+
+
+class TestVolumes(TestWithDocument):
+    def test_custom_bin_rectangle(self) -> None:
+        freecad.gridfinity_workbench.custom_shape.get_layout = lambda: [[True, True], [True, True]]
+        fcg.Command.get("CreateBinBlank").run()
+        obj1 = fcg.ActiveDocument.ActiveObject.Object
+        fcg.Command.get("CreateCustomBlankBin").run()
+        obj2 = fcg.ActiveDocument.ActiveObject.Object
+        self.assertAlmostEqual(obj1.Shape.Volume, obj2.Shape.Volume)
+
+    def test_custom_bin_l(self) -> None:
+        freecad.gridfinity_workbench.custom_shape.get_layout = lambda: [
+            [True, True, True],
+            [True, False, False],
+        ]
+        fcg.Command.get("CreateLBinBlank").run()
+        obj1 = fcg.ActiveDocument.ActiveObject.Object
+        fcg.Command.get("CreateCustomBlankBin").run()
+        obj2 = fcg.ActiveDocument.ActiveObject.Object
+        self.assertAlmostEqual(obj1.Shape.Volume, obj2.Shape.Volume)
+
+    def test_bin_blank(self) -> None:
+        fcg.Command.get("CreateBinBlank").run()
+        obj = fcg.ActiveDocument.ActiveObject.Object
+        obj.MagnetHoles = False
+        obj.recompute()
+        self.assertAlmostEqual(obj.Shape.Volume, 288887.4126750665)
+        obj.RecessedTopDepth = 3
+        obj.recompute()
+        self.assertAlmostEqual(obj.Shape.Volume, 270272.25637141115)
+        obj.RecessedTopDepth = 0
+        obj.StackingLip = False
+        obj.recompute()
+        self.assertAlmostEqual(obj.Shape.Volume, 286724.9489979051)
+
+    def test_bin_base(self) -> None:
+        fcg.Command.get("CreateBinBase").run()
+        obj = fcg.ActiveDocument.ActiveObject.Object
+        obj.MagnetHoles = False
+        obj.recompute()
+        self.assertAlmostEqual(obj.Shape.Volume, 43118.696363716575)
+
+    def test_bin(self) -> None:
+        fcg.Command.get("CreateSimpleStorageBin").run()
+        obj = fcg.ActiveDocument.ActiveObject.Object
+        obj.MagnetHoles = False
+        obj.recompute()
+        self.assertAlmostEqual(obj.Shape.Volume, 58187.690383500565)
+        obj.StackingLip = False
+        obj.recompute()
+        self.assertAlmostEqual(obj.Shape.Volume, 54707.472846542325)
+
+    def test_eco_bin(self) -> None:
+        fcg.Command.get("CreateEcoBin").run()
+        obj = fcg.ActiveDocument.ActiveObject.Object
+        obj.MagnetHoles = False
+        obj.recompute()
+        self.assertAlmostEqual(obj.Shape.Volume, 24728.976287436377)
+
+    def test_baseplate(self) -> None:
+        fcg.Command.get("CreateBaseplate").run()
+        obj = fcg.ActiveDocument.ActiveObject.Object
+        self.assertAlmostEqual(obj.Shape.Volume, 5034.2316047825325)
+
+    def test_magnet_baseplate(self) -> None:
+        fcg.Command.get("CreateMagnetBaseplate").run()
+        obj = fcg.ActiveDocument.ActiveObject.Object
+        self.assertAlmostEqual(obj.Shape.Volume, 12606.095388468213)
+
+    def test_screw_together_baseplate(self) -> None:
+        fcg.Command.get("CreateScrewTogetherBaseplate").run()
+        obj = fcg.ActiveDocument.ActiveObject.Object
+        self.assertAlmostEqual(obj.Shape.Volume, 22897.352081257995)

--- a/freecad/gridfinity_workbench/version.py
+++ b/freecad/gridfinity_workbench/version.py
@@ -1,3 +1,3 @@
 """Module containing version information."""
 
-__version__ = "0.11.2"
+__version__ = "0.11.3"

--- a/package.xml
+++ b/package.xml
@@ -5,9 +5,9 @@
 
   <description>This Workbench will generate several variations of parametric Gridfinity bins and baseplates that can be easily customized. </description>
 
-  <version>0.11.2</version>
+  <version>0.11.3</version>
 
-  <date>2025-03-16</date>
+  <date>2025-03-17</date>
 
   <license file="LICENSE">lgpl-2.1-or-later</license>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ py-modules = []
 
 [project]
 name = "gridfinityworkbench"
-version = "0.11.2"
+version = "0.11.3"
 
 [project.optional-dependencies]
 dev = ["mypy==1.15.0", "ruff==0.9.5", "freecad-stubs==1.0.20"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,4 @@ ignore = ["ANN003", "EM101", "EM102", "RET504", "TRY003", "S101", "SIM300"]
 # PT027  - pytest-unittest-raises-assertion: we use unittest framework, not pytest
 # PT009  - pytest-unittest-assertion: we use unittest framework, not pytest
 "**/tests/*" = ["INP001", "D100", "D101", "D102", "PT027", "PT009"]
+"freecad/gridfinity_workbench/test_gridfinity.py" = ["D100", "D101", "D102", "PT027", "PT009"]

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,0 @@
-FROM archlinux
-
-RUN pacman -Sy
-RUN pacman --noconfirm -S freecad


### PR DESCRIPTION
As there are some issues coming up that are caused mainly by me, I thought to improve the test system. FreeCAD has it's own way of running tests, which is not used at the moment IIUC.

You can run the new tests with `freecad -t freecad.gridfinity_workbench.test_gridfinity`.

I want to mainly include tests for working with saving and opening files, as this is the area of the issues. (and to be honest, I was too lazy to test these)

I will try to integrate the existing tests with the FreeCAD runner.