### PR TITLE
Deduplicate code in features.py

### DIFF
--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -1021,7 +1021,7 @@ def bin_base_values_properties(obj: fc.DocumentObject) -> None:
     )
     obj.setExpression(
         "BaseProfileHeight",
-        "BaseProfileBottomChamfer + BaseProfileVerticalSection + BaseProfileTopChamfer"
+        "BaseProfileBottomChamfer + BaseProfileVerticalSection + BaseProfileTopChamfer",
     )
 
 

--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -951,15 +951,6 @@ def bin_base_values_properties(obj: fc.DocumentObject) -> None:
         obj (FreeCAD.DocumentObject): Document object
 
     """
-    ## Reference Parameters
-    obj.addProperty(
-        "App::PropertyLength",
-        "BaseProfileHeight",
-        "ReferenceParameters",
-        "Height of the Gridfinity Base Profile, bottom of the bin",
-        1,
-    )
-
     ## Expert Only Parameters
     obj.addProperty(
         "App::PropertyLength",
@@ -1020,16 +1011,17 @@ def bin_base_values_properties(obj: fc.DocumentObject) -> None:
         ),
     ).Clearance = const.CLEARANCE
 
-
-def make_bin_base_values(obj: fc.DocumentObject) -> None:
-    """Generate Rectanble layout and calculate relevant parameters.
-
-    Args:
-        obj (FreeCAD.DocumentObject): Document object.
-
-    """
-    obj.BaseProfileHeight = (
-        obj.BaseProfileBottomChamfer + obj.BaseProfileVerticalSection + obj.BaseProfileTopChamfer
+    ## Reference Parameters
+    obj.addProperty(
+        "App::PropertyLength",
+        "BaseProfileHeight",
+        "ReferenceParameters",
+        "Height of the Gridfinity Base Profile, bottom of the bin",
+        1,
+    )
+    obj.setExpression(
+        "BaseProfileHeight",
+        "BaseProfileBottomChamfer + BaseProfileVerticalSection + BaseProfileTopChamfer"
     )
 
 

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -196,8 +196,6 @@ class BinBlank(FoundationGridfinity):
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         """Generate BinBlanek Shape."""
-        feat.make_bin_base_values(obj)
-
         layout = grid_initial_layout.make_rectangle_layout(obj)
 
         bin_outside_shape = utils.create_rounded_rectangle(
@@ -260,8 +258,6 @@ class BinBase(FoundationGridfinity):
         obj.Proxy = self
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
-        feat.make_bin_base_values(obj)
-
         layout = grid_initial_layout.make_rectangle_layout(obj)
 
         bin_outside_shape = utils.create_rounded_rectangle(
@@ -351,8 +347,6 @@ class SimpleStorageBin(FoundationGridfinity):
             Part.Shape: Storage bin shape.
 
         """
-        feat.make_bin_base_values(obj)
-
         layout = grid_initial_layout.make_rectangle_layout(obj)
 
         bin_outside_shape = utils.create_rounded_rectangle(
@@ -433,8 +427,6 @@ class EcoBin(FoundationGridfinity):
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         """Create gridfinity EcoBin shape."""
         ## Bin Construction
-
-        feat.make_bin_base_values(obj)
 
         layout = grid_initial_layout.make_rectangle_layout(obj)
 
@@ -525,8 +517,6 @@ class PartsBin(FoundationGridfinity):
             Part.Shape: Parts bin shape.
 
         """
-        feat.make_bin_base_values(obj)
-
         layout = grid_initial_layout.make_rectangle_layout(obj)
 
         bin_outside_shape = utils.create_rounded_rectangle(
@@ -752,8 +742,6 @@ class LBinBlank(FoundationGridfinity):
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         """Generate gridfinity L shaped bin."""
-        feat.make_bin_base_values(obj)
-
         layout = grid_initial_layout.make_l_shaped_layout(obj)
 
         bin_outside_shape = utils.create_rounded_l(

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -1,5 +1,7 @@
 """Feature modules contain bins an baseplate objects."""
 
+# ruff: noqa: D101, D107
+
 from abc import abstractmethod
 
 import FreeCAD as fc  # noqa: N813
@@ -75,8 +77,6 @@ class FoundationGridfinity:
 
 
 class CustomBin(FoundationGridfinity):
-    """Gridfinity CustomBin object."""
-
     def __init__(self, obj: fc.DocumentObject, layout: list[list[bool]]) -> None:
         super().__init__(obj)
         self.layout = layout
@@ -101,15 +101,6 @@ class CustomBin(FoundationGridfinity):
         obj.Proxy = self
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
-        """Generate BinBlanek Shape.
-
-        Args:
-            obj (FreeCAD.DocumentObject): Document object.
-
-        Returns:
-            Part.Shape: Bin Blank shape
-
-        """
         ## calculated here
         if obj.NonStandardHeight:
             obj.TotalHeight = obj.CustomHeight
@@ -241,10 +232,7 @@ class FullBin(FoundationGridfinity):
 
 
 class BinBlank(FullBin):
-    """Gridfinity BinBlank object."""
-
     def __init__(self, obj: fc.DocumentObject) -> None:
-        """Create BinBlank object."""
         super().__init__(
             obj,
             height_units_default=const.HEIGHT_UNITS,
@@ -299,7 +287,7 @@ class StorageBin(FoundationGridfinity):
         feat.scoop_properties(obj, scoop_default=scoop_default)
 
         obj.Proxy = self
-    
+
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         layout = grid_initial_layout.make_rectangle_layout(obj)
 
@@ -365,10 +353,7 @@ class PartsBin(StorageBin):
 
 
 class EcoBin(FoundationGridfinity):
-    """Eco Bin."""
-
     def __init__(self, obj: fc.DocumentObject) -> None:
-        """Initialize Eco bin properties."""
         super().__init__(obj)
 
         obj.addProperty(
@@ -393,9 +378,6 @@ class EcoBin(FoundationGridfinity):
         obj.Proxy = self
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
-        """Create gridfinity EcoBin shape."""
-        ## Bin Construction
-
         layout = grid_initial_layout.make_rectangle_layout(obj)
 
         bin_outside_shape = utils.create_rounded_rectangle(
@@ -443,10 +425,7 @@ class EcoBin(FoundationGridfinity):
 
 
 class Baseplate(FoundationGridfinity):
-    """BasePlate object."""
-
     def __init__(self, obj: fc.DocumentObject) -> None:
-        """Initialize Baseplate properties."""
         super().__init__(obj)
 
         obj.addProperty(
@@ -463,7 +442,6 @@ class Baseplate(FoundationGridfinity):
         obj.Proxy = self
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
-        """Generate Baseplate."""
         baseplate_feat.make_base_values(obj)
 
         layout = grid_initial_layout.make_rectangle_layout(obj)
@@ -490,10 +468,7 @@ class Baseplate(FoundationGridfinity):
 
 
 class MagnetBaseplate(FoundationGridfinity):
-    """Magnet baseplate object."""
-
     def __init__(self, obj: fc.DocumentObject) -> None:
-        """Initialize MagnetBaseplate properties."""
         super().__init__(obj)
 
         obj.addProperty(
@@ -512,7 +487,6 @@ class MagnetBaseplate(FoundationGridfinity):
         obj.Proxy = self
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
-        """Generate MagnetBaseplate shape."""
         baseplate_feat.make_base_values(obj)
 
         layout = grid_initial_layout.make_rectangle_layout(obj)
@@ -541,10 +515,7 @@ class MagnetBaseplate(FoundationGridfinity):
 
 
 class ScrewTogetherBaseplate(FoundationGridfinity):
-    """Screw together baseplate object."""
-
     def __init__(self, obj: fc.DocumentObject) -> None:
-        """Initialize ScrewTogetherBaseplate properties."""
         super().__init__(obj)
 
         obj.addProperty(
@@ -564,7 +535,6 @@ class ScrewTogetherBaseplate(FoundationGridfinity):
         baseplate_feat.connection_holes_properties(obj)
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
-        """Generate ScrewTogetherBaseplate shape."""
         baseplate_feat.make_base_values(obj)
 
         layout = grid_initial_layout.make_rectangle_layout(obj)
@@ -595,10 +565,7 @@ class ScrewTogetherBaseplate(FoundationGridfinity):
 
 
 class LBinBlank(FoundationGridfinity):
-    """L shaped blank bin object."""
-
     def __init__(self, obj: fc.DocumentObject) -> None:
-        """Initialize L shaped blank bin properties."""
         super().__init__(obj)
 
         obj.addProperty("App::PropertyPythonObject", "Bin", "base", "python gridfinity object")
@@ -617,7 +584,6 @@ class LBinBlank(FoundationGridfinity):
         obj.Proxy = self
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
-        """Generate gridfinity L shaped bin."""
         layout = grid_initial_layout.make_l_shaped_layout(obj)
 
         bin_outside_shape = utils.create_rounded_l(

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -245,6 +245,9 @@ class BinBase(FullBin):
             height_units_default=1,
             stacking_lip_default=False,
         )
+        obj.setEditorMode("StackingLip", 2)
+        obj.setEditorMode("RecessedTopDepth", 2)
+        obj.setEditorMode("WallThickness", 2)
 
 
 class StorageBin(FoundationGridfinity):

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -1,6 +1,6 @@
 """Feature modules contain bins an baseplate objects."""
 
-# ruff: noqa: D101, D107
+# ruff: noqa: D101, D102, D107
 
 from abc import abstractmethod
 

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -43,6 +43,8 @@ class FoundationGridfinity:
             1,
         ).version = __version__
 
+        obj.Proxy = self
+
     def execute(self, fp: Part.Feature) -> None:
         gridfinity_shape = self.generate_gridfinity_shape(fp)
 
@@ -97,8 +99,6 @@ class CustomBin(FoundationGridfinity):
         feat.stacking_lip_properties(obj, stacking_lip_default=const.STACKING_LIP)
         feat.bin_bottom_holes_properties(obj, magnet_holes_default=const.MAGNET_HOLES)
         feat.bin_base_values_properties(obj)
-
-        obj.Proxy = self
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         ## calculated here
@@ -190,8 +190,6 @@ class FullBin(FoundationGridfinity):
         feat.stacking_lip_properties(obj, stacking_lip_default=stacking_lip_default)
         feat.bin_bottom_holes_properties(obj, magnet_holes_default=const.MAGNET_HOLES)
         feat.bin_base_values_properties(obj)
-
-        obj.Proxy = self
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         layout = grid_initial_layout.make_rectangle_layout(obj)
@@ -286,8 +284,6 @@ class StorageBin(FoundationGridfinity):
         feat.label_shelf_properties(obj, label_style_default=label_style_default)
         feat.scoop_properties(obj, scoop_default=scoop_default)
 
-        obj.Proxy = self
-
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         layout = grid_initial_layout.make_rectangle_layout(obj)
 
@@ -375,8 +371,6 @@ class EcoBin(FoundationGridfinity):
         feat.label_shelf_properties(obj, label_style_default="Standard")
         feat.eco_compartments_properties(obj)
 
-        obj.Proxy = self
-
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         layout = grid_initial_layout.make_rectangle_layout(obj)
 
@@ -439,8 +433,6 @@ class Baseplate(FoundationGridfinity):
         baseplate_feat.solid_shape_properties(obj)
         baseplate_feat.base_values_properties(obj)
 
-        obj.Proxy = self
-
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         baseplate_feat.make_base_values(obj)
 
@@ -484,8 +476,6 @@ class MagnetBaseplate(FoundationGridfinity):
         baseplate_feat.magnet_holes_properties(obj)
         baseplate_feat.center_cut_properties(obj)
 
-        obj.Proxy = self
-
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         baseplate_feat.make_base_values(obj)
 
@@ -524,7 +514,6 @@ class ScrewTogetherBaseplate(FoundationGridfinity):
             "base",
             "python gridfinity object",
         )
-        obj.Proxy = self
 
         grid_initial_layout.rectangle_layout_properties(obj, baseplate_default=True)
         baseplate_feat.solid_shape_properties(obj)
@@ -580,8 +569,6 @@ class LBinBlank(FoundationGridfinity):
         feat.stacking_lip_properties(obj, stacking_lip_default=const.STACKING_LIP)
         feat.bin_bottom_holes_properties(obj, magnet_holes_default=const.MAGNET_HOLES)
         feat.bin_base_values_properties(obj)
-
-        obj.Proxy = self
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         layout = grid_initial_layout.make_l_shaped_layout(obj)

--- a/freecad/gridfinity_workbench/version.py
+++ b/freecad/gridfinity_workbench/version.py
@@ -1,3 +1,3 @@
 """Module containing version information."""
 
-__version__ = "0.10.4"
+__version__ = "0.10.5"

--- a/package.xml
+++ b/package.xml
@@ -5,9 +5,9 @@
 
   <description>This Workbench will generate several variations of parametric Gridfinity bins and baseplates that can be easily customized. </description>
 
-  <version>0.10.4</version>
+  <version>0.10.5</version>
 
-  <date>2025-03-08</date>
+  <date>2025-03-11</date>
 
   <license file="LICENSE">lgpl-2.1-or-later</license>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ py-modules = []
 
 [project]
 name = "gridfinityworkbench"
-version = "0.10.4"
+version = "0.10.5"
 
 [project.optional-dependencies]
 dev = ["mypy==1.15.0", "ruff==0.9.5", "freecad-stubs==1.0.20"]


### PR DESCRIPTION
Main changes:
- Made `BaseProfileHeight` an expression, `make_bin_base_values` is no longer needed.
- Moved `obj.Proxy = self` to `FoundationGridfinity` so it doesn't have to be repeated in every class.
- As the SimpleStorageBin and PartsBin are basically the same think, just with different initial values, I extracted the code to a new superclass StorageBin. The same for BinBlank and BinBase. I checked the diff between both `__init__` and `generate_gridfinity_shape`, and they were just identical (with the exception of the numbers in `__init__`).
- I got annoyed by pointless "Gridfinity FooBar object", "Initialize FooBar properties" and "Generate FooBar shape" docstrings, so I added `ruff: noqa: D101, D102, D107` for the whole file. But please use the docstrings if they add any value – for example to indicate that a class in not a workbench command (like in the new classes added).