### PR TITLE
Cleanup

### DIFF
--- a/freecad/gridfinity_workbench/commands.py
+++ b/freecad/gridfinity_workbench/commands.py
@@ -14,25 +14,6 @@ import FreeCAD as fc  # noqa: N813
 import FreeCADGui as fcg  # noqa: N813
 
 from . import custom_shape, features, utils
-from .features import (
-    Baseplate,
-    BinBase,
-    BinBlank,
-    CustomBaseplate,
-    CustomBinBase,
-    CustomBlankBin,
-    CustomEcoBin,
-    CustomMagnetBaseplate,
-    CustomScrewTogetherBaseplate,
-    CustomStorageBin,
-    EcoBin,
-    FoundationGridfinity,
-    LBinBlank,
-    MagnetBaseplate,
-    PartsBin,
-    ScrewTogetherBaseplate,
-    SimpleStorageBin,
-)
 
 if TYPE_CHECKING:
     import Part
@@ -127,7 +108,7 @@ class CreateCommand(BaseCommand):
         self,
         *,
         name: str,
-        gridfinity_function: type[FoundationGridfinity],
+        gridfinity_function: type[features.FoundationGridfinity],
         pixmap: Path,
     ) -> None:
         super().__init__(
@@ -155,7 +136,7 @@ class CreateBinBlank(CreateCommand):
     def __init__(self) -> None:
         super().__init__(
             name="BinBlank",
-            gridfinity_function=BinBlank,
+            gridfinity_function=features.BinBlank,
             pixmap=ICONDIR / "BinBlank.svg",
         )
 
@@ -164,7 +145,7 @@ class CreateBinBase(CreateCommand):
     def __init__(self) -> None:
         super().__init__(
             name="BinBase",
-            gridfinity_function=BinBase,
+            gridfinity_function=features.BinBase,
             pixmap=ICONDIR / "BinBase.svg",
         )
 
@@ -173,7 +154,7 @@ class CreateSimpleStorageBin(CreateCommand):
     def __init__(self) -> None:
         super().__init__(
             name="SimpleStorageBin",
-            gridfinity_function=SimpleStorageBin,
+            gridfinity_function=features.SimpleStorageBin,
             pixmap=ICONDIR / "SimpleStorageBin.svg",
         )
 
@@ -182,7 +163,7 @@ class CreateEcoBin(CreateCommand):
     def __init__(self) -> None:
         super().__init__(
             name="EcoBin",
-            gridfinity_function=EcoBin,
+            gridfinity_function=features.EcoBin,
             pixmap=ICONDIR / "eco_bin.svg",
         )
 
@@ -191,7 +172,7 @@ class CreatePartsBin(CreateCommand):
     def __init__(self) -> None:
         super().__init__(
             name="PartsBin",
-            gridfinity_function=PartsBin,
+            gridfinity_function=features.PartsBin,
             pixmap=ICONDIR / "parts_bin.svg",
         )
 
@@ -200,7 +181,7 @@ class CreateBaseplate(CreateCommand):
     def __init__(self) -> None:
         super().__init__(
             name="Baseplate",
-            gridfinity_function=Baseplate,
+            gridfinity_function=features.Baseplate,
             pixmap=ICONDIR / "Baseplate.svg",
         )
 
@@ -209,7 +190,7 @@ class CreateMagnetBaseplate(CreateCommand):
     def __init__(self) -> None:
         super().__init__(
             name="MagnetBaseplate",
-            gridfinity_function=MagnetBaseplate,
+            gridfinity_function=features.MagnetBaseplate,
             pixmap=ICONDIR / "magnet_baseplate.svg",
         )
 
@@ -218,7 +199,7 @@ class CreateScrewTogetherBaseplate(CreateCommand):
     def __init__(self) -> None:
         super().__init__(
             name="ScrewTogetherBaseplate",
-            gridfinity_function=ScrewTogetherBaseplate,
+            gridfinity_function=features.ScrewTogetherBaseplate,
             pixmap=ICONDIR / "screw_together_baseplate.svg",
         )
 
@@ -227,7 +208,7 @@ class CreateLBinBlank(CreateCommand):
     def __init__(self) -> None:
         super().__init__(
             name="LShapedBlankBin",
-            gridfinity_function=LBinBlank,
+            gridfinity_function=features.LBinBlank,
             pixmap=ICONDIR / "BetaLBinBlank.svg",
         )
 
@@ -282,10 +263,10 @@ class DrawBin(DrawCommand):
             tooltip="Draw a custom gridfinity bin of any type.",
             gridfinity_functions=OrderedDict(
                 [
-                    ("Blank Bin", CustomBlankBin),
-                    ("Bin Base", CustomBinBase),
-                    ("Storage Bin", CustomStorageBin),
-                    ("Eco Bin", CustomEcoBin),
+                    ("Blank Bin", features.CustomBlankBin),
+                    ("Bin Base", features.CustomBinBase),
+                    ("Storage Bin", features.CustomStorageBin),
+                    ("Eco Bin", features.CustomEcoBin),
                 ],
             ),
         )
@@ -300,9 +281,9 @@ class DrawBaseplate(DrawCommand):
             tooltip="Draw a custom gridfinity baseplate of any type.",
             gridfinity_functions=OrderedDict(
                 [
-                    ("Simple Baseplate", CustomBaseplate),
-                    ("Magnet Baseplate", CustomMagnetBaseplate),
-                    ("Screw Together Baseplate", CustomScrewTogetherBaseplate),
+                    ("Simple Baseplate", features.CustomBaseplate),
+                    ("Magnet Baseplate", features.CustomMagnetBaseplate),
+                    ("Screw Together Baseplate", features.CustomScrewTogetherBaseplate),
                 ],
             ),
         )

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -23,18 +23,6 @@ from .version import __version__
 unitmm = fc.Units.Quantity("1 mm")
 
 
-__all__ = [
-    "Baseplate",
-    "BinBlank",
-    "EcoBin",
-    "EcoBin",
-    "LBinBlank",
-    "MagnetBaseplate",
-    "PartsBin",
-    "ScrewTogetherBaseplate",
-]
-
-
 class FoundationGridfinity:
     def __init__(self, obj: fc.DocumentObject) -> None:
         obj.addProperty(
@@ -42,7 +30,7 @@ class FoundationGridfinity:
             "version",
             "version",
             "Gridfinity Workbench Version",
-            1,
+            read_only=True,
         ).version = __version__
 
         obj.Proxy = self
@@ -374,8 +362,6 @@ class Baseplate(FoundationGridfinity):
         baseplate_feat.base_values_properties(obj)
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
-        baseplate_feat.make_base_values(obj)
-
         layout = grid_initial_layout.make_rectangle_layout(obj)
 
         baseplate_outside_shape = utils.create_rounded_rectangle(
@@ -417,8 +403,6 @@ class MagnetBaseplate(FoundationGridfinity):
         baseplate_feat.center_cut_properties(obj)
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
-        baseplate_feat.make_base_values(obj)
-
         layout = grid_initial_layout.make_rectangle_layout(obj)
 
         baseplate_outside_shape = utils.create_rounded_rectangle(
@@ -464,8 +448,6 @@ class ScrewTogetherBaseplate(FoundationGridfinity):
         baseplate_feat.connection_holes_properties(obj)
 
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
-        baseplate_feat.make_base_values(obj)
-
         layout = grid_initial_layout.make_rectangle_layout(obj)
 
         baseplate_outside_shape = utils.create_rounded_rectangle(
@@ -581,11 +563,6 @@ class CustomBlankBin(FoundationGridfinity):
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         """Generate BinBlank Shape."""
         ## calculated here
-        if obj.NonStandardHeight:
-            obj.TotalHeight = obj.CustomHeight
-
-        else:
-            obj.TotalHeight = obj.HeightUnits * obj.HeightUnitValue
 
         obj.BaseProfileHeight = (
             obj.BaseProfileBottomChamfer
@@ -599,7 +576,7 @@ class CustomBlankBin(FoundationGridfinity):
         ## calculated values over
         grid_initial_layout.make_custom_shape_layout(obj, self.layout)
         solid_shape = custom_shape_solid(obj, self.layout, obj.TotalHeight - obj.BaseProfileHeight)
-        outside_trim = custom_shape_trim(obj, self.layout, obj.Clearance.Value, obj.Clearance.Value)
+        outside_trim = custom_shape_trim(obj, self.layout, obj.Clearance, obj.Clearance)
         fuse_total = solid_shape.cut(outside_trim)
         fuse_total = fuse_total.removeSplitter()
         fuse_total = vertical_edge_fillet(fuse_total, obj.BinOuterRadius)
@@ -670,12 +647,6 @@ class CustomBinBase(FoundationGridfinity):
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         """Generate BinBase Shape."""
         ## calculated here
-        if obj.NonStandardHeight:
-            obj.TotalHeight = obj.CustomHeight
-
-        else:
-            obj.TotalHeight = obj.HeightUnits * obj.HeightUnitValue
-
         obj.BaseProfileHeight = (
             obj.BaseProfileBottomChamfer
             + obj.BaseProfileVerticalSection
@@ -760,10 +731,6 @@ class CustomEcoBin(FoundationGridfinity):
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         """Generate EcoBin Shape."""
         ## calculated here
-        if obj.NonStandardHeight:
-            obj.TotalHeight = obj.CustomHeight
-        else:
-            obj.TotalHeight = obj.HeightUnits * obj.HeightUnitValue
 
         obj.BaseProfileHeight = (
             obj.BaseProfileBottomChamfer
@@ -970,7 +937,6 @@ class CustomBaseplate(FoundationGridfinity):
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         """Generate Baseplate Shape."""
         ## calculated here
-        baseplate_feat.make_base_values(obj)
         obj.TotalHeight = obj.BaseProfileHeight
 
         ## calculated values over
@@ -1024,7 +990,6 @@ class CustomMagnetBaseplate(FoundationGridfinity):
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         """Generate MagnetBaseplate Shape."""
         ## calculated here
-        baseplate_feat.make_base_values(obj)
         obj.TotalHeight = obj.BaseProfileHeight + obj.MagnetHoleDepth + obj.MagnetBase
 
         ## calculated values over
@@ -1082,7 +1047,6 @@ class CustomScrewTogetherBaseplate(FoundationGridfinity):
     def generate_gridfinity_shape(self, obj: fc.DocumentObject) -> Part.Shape:
         """Generate Screw Together Baseplate Shape."""
         ## calculated here
-        baseplate_feat.make_base_values(obj)
         obj.TotalHeight = obj.BaseProfileHeight + obj.BaseThickness
 
         ## calculated values over
@@ -1126,7 +1090,7 @@ class StandaloneLabelShelf:
             "version",
             "version",
             "Gridfinity Workbench Version",
-            1,
+            read_only=True,
         ).version = __version__
 
         obj.addProperty(

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -661,7 +661,7 @@ class CustomBinBase(FoundationGridfinity):
         layout = clean_up_layout(self.layout)
         grid_initial_layout.make_custom_shape_layout(obj, layout)
         solid_shape = custom_shape_solid(obj, layout, obj.TotalHeight - obj.BaseProfileHeight)
-        outside_trim = custom_shape_trim(obj, layout, obj.Clearance.Value, obj.Clearance.Value)
+        outside_trim = custom_shape_trim(obj, layout, obj.Clearance, obj.Clearance)
         fuse_total = solid_shape.cut(outside_trim)
         fuse_total = fuse_total.removeSplitter()
         fuse_total = vertical_edge_fillet(fuse_total, obj.BinOuterRadius)
@@ -747,7 +747,7 @@ class CustomEcoBin(FoundationGridfinity):
         layout = clean_up_layout(self.layout)
         grid_initial_layout.make_custom_shape_layout(obj, layout)
         solid_shape = custom_shape_solid(obj, layout, obj.TotalHeight - obj.BaseProfileHeight)
-        outside_trim = custom_shape_trim(obj, layout, obj.Clearance.Value, obj.Clearance.Value)
+        outside_trim = custom_shape_trim(obj, layout, obj.Clearance, obj.Clearance)
         fuse_total = solid_shape.cut(outside_trim)
         fuse_total = fuse_total.removeSplitter()
         fuse_total = vertical_edge_fillet(fuse_total, obj.BinOuterRadius)
@@ -762,8 +762,8 @@ class CustomEcoBin(FoundationGridfinity):
         compartment_trim = custom_shape_trim(
             obj,
             layout,
-            obj.Clearance.Value + obj.WallThickness.Value,
-            obj.Clearance.Value + obj.WallThickness.Value,
+            obj.Clearance + obj.WallThickness,
+            obj.Clearance + obj.WallThickness,
         )
         compartments_solid = compartments_solid.cut(compartment_trim)
         compartments_solid = compartments_solid.removeSplitter()
@@ -864,7 +864,7 @@ class CustomStorageBin(FoundationGridfinity):
         layout = clean_up_layout(self.layout)
         grid_initial_layout.make_custom_shape_layout(obj, layout)
         solid_shape = custom_shape_solid(obj, layout, obj.TotalHeight - obj.BaseProfileHeight)
-        outside_trim = custom_shape_trim(obj, layout, obj.Clearance.Value, obj.Clearance.Value)
+        outside_trim = custom_shape_trim(obj, layout, obj.Clearance, obj.Clearance)
         fuse_total = solid_shape.cut(outside_trim)
         fuse_total = fuse_total.removeSplitter()
         fuse_total = vertical_edge_fillet(fuse_total, obj.BinOuterRadius)
@@ -874,8 +874,8 @@ class CustomStorageBin(FoundationGridfinity):
         compartment_trim = custom_shape_trim(
             obj,
             layout,
-            obj.Clearance.Value + obj.WallThickness.Value,
-            obj.Clearance.Value + obj.WallThickness.Value,
+            obj.Clearance + obj.WallThickness,
+            obj.Clearance + obj.WallThickness,
         )
         compartments_solid = compartments_solid.cut(compartment_trim)
         compartments_solid = compartments_solid.removeSplitter()

--- a/freecad/gridfinity_workbench/grid_initial_layout.py
+++ b/freecad/gridfinity_workbench/grid_initial_layout.py
@@ -19,16 +19,16 @@ def _location_properties(obj: fc.DocumentObject) -> None:
         "xLocationOffset",
         "ShouldBeHidden",
         "changing bin location in the x direction",
+        hidden=True,
     )
-    obj.setEditorMode("xLocationOffset", 2)
 
     obj.addProperty(
         "App::PropertyLength",
         "yLocationOffset",
         "ShouldBeHidden",
         "changing bin location in the y direction",
+        hidden=True,
     )
-    obj.setEditorMode("yLocationOffset", 2)
 
 
 def _total_width_properties(obj: fc.DocumentObject) -> None:
@@ -38,7 +38,7 @@ def _total_width_properties(obj: fc.DocumentObject) -> None:
         "xTotalWidth",
         "ReferenceParameters",
         "total width of Gridfinity object in x direction",
-        1,
+        read_only=True,
     )
 
     obj.addProperty(
@@ -46,7 +46,7 @@ def _total_width_properties(obj: fc.DocumentObject) -> None:
         "yTotalWidth",
         "ReferenceParameters",
         "total width of Gridfinity object in y direction",
-        1,
+        read_only=True,
     )
 
 
@@ -100,40 +100,34 @@ def rectangle_layout_properties(obj: fc.DocumentObject, *, baseplate_default: bo
         "Baseplate",
         "ShouldBeHidden",
         "Is the Gridfinity Object a baseplate",
+        hidden=True,
     ).Baseplate = baseplate_default
 
-    obj.setEditorMode("Baseplate", 2)
+    ## Expressions
+    obj.setExpression(
+        "xTotalWidth",
+        "xGridUnits * xGridSize - (Baseplate == 1 ? 0mm : 2 * Clearance)",
+    )
+    obj.setExpression(
+        "yTotalWidth",
+        "yGridUnits * yGridSize - (Baseplate == 1 ? 0mm : 2 * Clearance)",
+    )
 
 
 def make_rectangle_layout(obj: fc.DocumentObject) -> list[list[bool]]:
-    """Generate Rectanble layout and calculate relevant parameters.
-
-    Args:
-        obj (FreeCAD.DocumentObject): Document object.
-
-    Returns:
-        rectangle_layout: 2 dimentional list of feature locations
-
-    """
-    if obj.Baseplate:
-        obj.xTotalWidth = obj.xGridUnits * obj.xGridSize
-        obj.yTotalWidth = obj.yGridUnits * obj.yGridSize
-    else:
-        obj.xTotalWidth = obj.xGridUnits * obj.xGridSize - obj.Clearance * 2
-        obj.yTotalWidth = obj.yGridUnits * obj.yGridSize - obj.Clearance * 2
-
+    """Generate Rectanble layout and calculate relevant parameters."""
     if obj.GenerationLocation == "Centered at Origin":
         if obj.Baseplate:
             obj.xLocationOffset = obj.xTotalWidth / 2
             obj.yLocationOffset = obj.yTotalWidth / 2
         else:
-            obj.xLocationOffset = (obj.xTotalWidth + obj.Clearance * 2) / 2
-            obj.yLocationOffset = (obj.yTotalWidth + obj.Clearance * 2) / 2
+            obj.xLocationOffset = obj.xTotalWidth / 2 + obj.Clearance
+            obj.yLocationOffset = obj.yTotalWidth / 2 + obj.Clearance
     else:
         obj.xLocationOffset = 0
         obj.yLocationOffset = 0
 
-    return [[True for y in range(obj.yGridUnits)] for x in range(obj.xGridUnits)]
+    return [[True] * obj.yGridUnits for x in range(obj.xGridUnits)]
 
 
 def l_shaped_layout_properties(obj: fc.DocumentObject, *, baseplate_default: bool) -> None:
@@ -180,28 +174,28 @@ def l_shaped_layout_properties(obj: fc.DocumentObject, *, baseplate_default: boo
         "x1TotalDimension",
         "ReferenceDimensions",
         "total dimension of the gridfintiy object in the x direction",
-        1,
+        read_only=True,
     )
     obj.addProperty(
         "App::PropertyLength",
         "y1TotalDimension",
         "ReferenceDimensions",
         "total dimension of the gridfintiy object in the y direction",
-        1,
+        read_only=True,
     )
     obj.addProperty(
         "App::PropertyLength",
         "x2TotalDimension",
         "ReferenceDimensions",
         "total width of the L part in the x direction",
-        1,
+        read_only=True,
     )
     obj.addProperty(
         "App::PropertyLength",
         "y2TotalDimension",
         "ReferenceDimensions",
         "total width of the L part in the y direction",
-        1,
+        read_only=True,
     )
     ## Hidden Properties
     obj.addProperty(
@@ -209,8 +203,8 @@ def l_shaped_layout_properties(obj: fc.DocumentObject, *, baseplate_default: boo
         "Baseplate",
         "Flags",
         "Is the Gridfinity Object a baseplate",
+        hidden=True,
     ).Baseplate = baseplate_default
-    obj.setEditorMode("Baseplate", 2)
 
 
 def make_l_shaped_layout(obj: fc.DocumentObject) -> list[list[bool]]:
@@ -286,8 +280,8 @@ def custom_shape_layout_properties(obj: fc.DocumentObject, *, baseplate_default:
         "Baseplate",
         "ShouldBeHidden",
         "Is the Gridfinity Object a baseplate",
+        hidden=True,
     ).Baseplate = baseplate_default
-    obj.setEditorMode("Baseplate", 2)
 
 
 def make_custom_shape_layout(obj: fc.DocumentObject, layout: list[list[bool]]) -> None:

--- a/freecad/gridfinity_workbench/init_gui.py
+++ b/freecad/gridfinity_workbench/init_gui.py
@@ -3,6 +3,7 @@
 The file name is given by FreeCAD. FreeCAD uses this file to initialize GUI components.
 """
 
+from collections import OrderedDict
 from pathlib import Path
 
 import FreeCAD as fc  # noqa: N813
@@ -48,19 +49,22 @@ class GridfinityWorkbench(Workbench):
 
         fc.Console.PrintMessage("switching to Gridfinity Workbench\n")
 
-        workbench_commands = {
-            "CreateBinBlank": commands.CreateBinBlank(),
-            "CreateBinBase": commands.CreateBinBase(),
-            "CreateSimpleStorageBin": commands.CreateSimpleStorageBin(),
-            "CreateEcoBin": commands.CreateEcoBin(),
-            "CreatePartsBin": commands.CreatePartsBin(),
-            "CreateBaseplate": commands.CreateBaseplate(),
-            "CreateMagnetBaseplate": commands.CreateMagnetBaseplate(),
-            "CreateScrewTogetherBaseplate": commands.CreateScrewTogetherBaseplate(),
-            "CreateCustomBin": commands.DrawBin(),
-            "CreateCustomBaseplate": commands.DrawBaseplate(),
-            "StandaloneLabelShelf": commands.StandaloneLabelShelf(),
-        }
+        workbench_commands = OrderedDict(
+            [
+                ("CreateBinBlank", commands.CreateBinBlank()),
+                ("CreateBinBase", commands.CreateBinBase()),
+                ("CreateSimpleStorageBin", commands.CreateSimpleStorageBin()),
+                ("CreateEcoBin", commands.CreateEcoBin()),
+                ("CreatePartsBin", commands.CreatePartsBin()),
+                ("CreateBaseplate", commands.CreateBaseplate()),
+                ("CreateMagnetBaseplate", commands.CreateMagnetBaseplate()),
+                ("CreateScrewTogetherBaseplate", commands.CreateScrewTogetherBaseplate()),
+                ("CreateCustomBin", commands.DrawBin()),
+                ("CreateCustomBaseplate", commands.DrawBaseplate()),
+                ("ChangeLayout", commands.ChangeLayout()),
+                ("StandaloneLabelShelf", commands.StandaloneLabelShelf()),
+            ],
+        )
 
         for command_name, command in workbench_commands.items():
             fcg.addCommand(command_name, command)

--- a/freecad/gridfinity_workbench/init_gui.py
+++ b/freecad/gridfinity_workbench/init_gui.py
@@ -4,21 +4,16 @@ The file name is given by FreeCAD. FreeCAD uses this file to initialize GUI comp
 """
 
 from pathlib import Path
-from typing import ClassVar
 
 import FreeCAD as fc  # noqa: N813
 import FreeCADGui as fcg  # noqa: N813
 
 try:
     from FreeCADGui import Workbench
-
 except ImportError:
     fc.Console.PrintWarning(
-        "you are using the GridfinityWorkbench with an old version of FreeCAD (<0.16)",
-    )
-
-    fc.Console.PrintWarning(
-        "the class Workbench is loaded, although not imported: magic",
+        "you are using the GridfinityWorkbench with an old version of FreeCAD (<0.16)\n"
+        "the class Workbench is loaded, although not imported: magic\n",
     )
 
 
@@ -33,21 +28,6 @@ class GridfinityWorkbench(Workbench):
     ToolTip = "FreeCAD Gridfinity Workbench"
 
     Icon = str(ICONPATH / "gridfinity_workbench_icon.svg")
-
-    toolbox: ClassVar[list[str]] = [
-        "CreateBinBlank",
-        "CreateBinBase",
-        "CreateSimpleStorageBin",
-        "CreateEcoBin",
-        "CreatePartsBin",
-        "CreateBaseplate",
-        "CreateMagnetBaseplate",
-        "CreateScrewTogetherBaseplate",
-        "CreateLBinBlank",
-        "CreateCustomBin",
-        "CreateCustomBaseplate",
-        "StandaloneLabelShelf",
-    ]
 
     def GetClassName(self) -> str:  # noqa: N802
         """Get freecad internal class name.
@@ -64,39 +44,30 @@ class GridfinityWorkbench(Workbench):
         This function is called at the first activation of the workbench.
         here is the place to import all the commands.
         """
-        from .commands import (
-            CreateBaseplate,
-            CreateBinBase,
-            CreateBinBlank,
-            CreateEcoBin,
-            CreateLBinBlank,
-            CreateMagnetBaseplate,
-            CreatePartsBin,
-            CreateScrewTogetherBaseplate,
-            CreateSimpleStorageBin,
-            DrawBaseplate,
-            DrawBin,
-            StandaloneLabelShelf,
-        )
+        from . import commands
 
         fc.Console.PrintMessage("switching to Gridfinity Workbench\n")
 
-        self.appendToolbar("Gridfinity", self.toolbox)
+        workbench_commands = {
+            "CreateBinBlank": commands.CreateBinBlank(),
+            "CreateBinBase": commands.CreateBinBase(),
+            "CreateSimpleStorageBin": commands.CreateSimpleStorageBin(),
+            "CreateEcoBin": commands.CreateEcoBin(),
+            "CreatePartsBin": commands.CreatePartsBin(),
+            "CreateBaseplate": commands.CreateBaseplate(),
+            "CreateMagnetBaseplate": commands.CreateMagnetBaseplate(),
+            "CreateScrewTogetherBaseplate": commands.CreateScrewTogetherBaseplate(),
+            "CreateLBinBlank": commands.CreateLBinBlank(),
+            "CreateCustomBin": commands.DrawBin(),
+            "CreateCustomBaseplate": commands.DrawBaseplate(),
+            "StandaloneLabelShelf": commands.StandaloneLabelShelf(),
+        }
 
-        self.appendMenu("Gridfinity", self.toolbox)
+        for command_name, command in workbench_commands.items():
+            fcg.addCommand(command_name, command)
 
-        fcg.addCommand("CreateBinBlank", CreateBinBlank())
-        fcg.addCommand("CreateBinBase", CreateBinBase())
-        fcg.addCommand("CreateSimpleStorageBin", CreateSimpleStorageBin())
-        fcg.addCommand("CreateEcoBin", CreateEcoBin())
-        fcg.addCommand("CreatePartsBin", CreatePartsBin())
-        fcg.addCommand("CreateBaseplate", CreateBaseplate())
-        fcg.addCommand("CreateMagnetBaseplate", CreateMagnetBaseplate())
-        fcg.addCommand("CreateScrewTogetherBaseplate", CreateScrewTogetherBaseplate())
-        fcg.addCommand("CreateLBinBlank", CreateLBinBlank())
-        fcg.addCommand("CreateCustomBin", DrawBin())
-        fcg.addCommand("CreateCustomBaseplate", DrawBaseplate())
-        fcg.addCommand("StandaloneLabelShelf", StandaloneLabelShelf())
+        self.appendToolbar("Gridfinity", list(workbench_commands.keys()))
+        self.appendMenu("Gridfinity", list(workbench_commands.keys()))
 
 
 fcg.addWorkbench(GridfinityWorkbench())

--- a/freecad/gridfinity_workbench/test_gridfinity.py
+++ b/freecad/gridfinity_workbench/test_gridfinity.py
@@ -21,7 +21,6 @@ SIMPLE_COMMANDS = [
     "CreateBaseplate",
     "CreateMagnetBaseplate",
     "CreateScrewTogetherBaseplate",
-    "CreateLBinBlank",
 ]
 
 CUSTOM_BIN_COMMANDS = [
@@ -96,7 +95,6 @@ class TestGenerationLocation(TestWithDocument):
     def setUp(self) -> None:
         super().setUp()
         self.commands = SIMPLE_COMMANDS.copy()
-        self.commands.remove("CreateLBinBlank")
 
     def test_positive_from_origin(self) -> None:
         for command_name in self.commands:
@@ -133,20 +131,6 @@ class TestVolumes(TestWithDocument):
             bin_type="Blank Bin",
         )
         fcg.Command.get("CreateBinBlank").run()
-        obj1 = fcg.ActiveDocument.ActiveObject.Object
-        fcg.Command.get("CreateCustomBin").run()
-        obj2 = fcg.ActiveDocument.ActiveObject.Object
-        self.assertAlmostEqual(obj1.Shape.Volume, obj2.Shape.Volume)
-
-    def test_custom_bin_l(self) -> None:
-        custom_shape.custom_bin_dialog = lambda _1, _2: GridDialogData(
-            layout=[
-                [True, True, True],
-                [True, False, False],
-            ],
-            bin_type="Blank Bin",
-        )
-        fcg.Command.get("CreateLBinBlank").run()
         obj1 = fcg.ActiveDocument.ActiveObject.Object
         fcg.Command.get("CreateCustomBin").run()
         obj2 = fcg.ActiveDocument.ActiveObject.Object

--- a/freecad/gridfinity_workbench/version.py
+++ b/freecad/gridfinity_workbench/version.py
@@ -1,3 +1,3 @@
 """Module containing version information."""
 
-__version__ = "0.11.5"
+__version__ = "0.11.6"

--- a/package.xml
+++ b/package.xml
@@ -5,9 +5,9 @@
 
   <description>This Workbench will generate several variations of parametric Gridfinity bins and baseplates that can be easily customized. </description>
 
-  <version>0.11.5</version>
+  <version>0.11.6</version>
 
-  <date>2025-04-05</date>
+  <date>2025-04-06</date>
 
   <license file="LICENSE">lgpl-2.1-or-later</license>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ py-modules = []
 
 [project]
 name = "gridfinityworkbench"
-version = "0.11.5"
+version = "0.11.6"
 
 [project.optional-dependencies]
 dev = ["mypy==1.15.0", "ruff==0.9.5", "freecad-stubs==1.0.20"]


### PR DESCRIPTION
1. In `init_gui.py` created a single source of truth for commands, and used it to register commands, and appending to toolbar and menu. This means you only need to add one line when adding a new command, making it much easier.
2. In `commands.py` referred to features by the `feature` package name, so you don't have to import every single feature on the top
3. Changed many `xtranslate` and `ytranslate` to `x * obj.xGridSize` and `y * obj.yGridSize` (or a proper expression that was added in each loop) to make it easier to read.
4. Many of those I replaced with a new `copy_in_layout` utility function
5. For the cases that loops were needed, I changed them to
    ```py
    for x, col in enumerate(layout):
        for y, cell in enumerate(row):
            if cell:
                do_something(x, y)
    ```
    When you need an index during iteration, using `enumerate` is more pythonic than `for i range(len(list))` and then `list[i]`.
6. Changed many
    ```py
    result = []
    for x in list:
        if condiditon(x):
            result.append(x)
    ```
    To a more pythonic list comprehension syntax:
    ```py
    result = [
        x
        for x in list
        if condition(x)
    ]
    ```
7. Moved the `make_fillet()` function from `utils.py` inside the `feature_construction.py:_corner_fillets()`, as it was only used there. This made `_corner_fillets()` a little less messy.
8. Moved the definition of `GridfinityLayout` from 3 different files to `utils.py`
9. Changed many `setEditorMode` and `addProperty` argument `attr` usage to `addProperty` flags `hidden` and `read_only` as they are more readable
10. Simplified code in `feature_construction.py:_stacking_lip_profile` by extracting values into variables
11. Used the expression engine for `xTotalWidth` and `yTotalWidth` in rectangle layout, and for `TotalHeight` for bins