### PR TITLE
Fix fillet height for custom divider height

### DIFF
--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -455,8 +455,12 @@ def _make_compartments_with_deviders(
         func_fuse = func_fuse.cut(xdiv)
     if ydiv:
         func_fuse = func_fuse.cut(ydiv)
+    if obj.yDividerHeight > 0 or obj.xDividerHeight > 0:
+        fillet_height = -obj.TotalHeight + min(obj.yDividerHeight, obj.xDividerHeight)
+    else:
+        fillet_height = 0
 
-    func_fuse = func_fuse.cut(_corner_fillets(obj, xcomp_w, ycomp_w))
+    func_fuse = func_fuse.cut(_corner_fillets(obj, xcomp_w, ycomp_w).translate(fc.Vector(0, 0, fillet_height)))
 
     return func_fuse
 


### PR DESCRIPTION
-Fix for #124 

Checks for lower divider height and lowers fillets to match. 

If x and y divider heights are different the fillets will only go up to the lower one as they are just and extruded cut and can't differentiate between the different scenarios. 

![image](https://github.com/user-attachments/assets/b60ede5c-4c5f-4684-a210-8f5f29f95c02)

I think this is acceptable as there are probably limited users using both at a different height and it still works. 