### PR TITLE
Refactor holes

### DIFF
--- a/freecad/gridfinity_workbench/baseplate_feature_construction.py
+++ b/freecad/gridfinity_workbench/baseplate_feature_construction.py
@@ -14,58 +14,6 @@ from .utils import GridfinityLayout
 
 def _magnet_hole_hex(
     obj: fc.DocumentObject,
-    x_hole_pos: float,
-    y_hole_pos: float,
-) -> Part.Shape:
-    # Ratio of 2/sqrt(3) converts from inscribed circle radius to circumscribed circle radius
-    radius = obj.MagnetHoleDiameter / math.sqrt(3)
-    n_sides = 6
-    rot = fc.Rotation(fc.Vector(0, 0, 1), 0)
-
-    p = fc.ActiveDocument.addObject("Part::RegularPolygon")
-    p.Polygon = n_sides
-    p.Circumradius = radius
-    p.Placement = fc.Placement(fc.Vector(-x_hole_pos, -y_hole_pos), rot)
-    p.recompute()
-    f = Part.Face(Part.Wire(p.Shape.Edges))
-    c1 = f.extrude(fc.Vector(0, 0, -obj.MagnetHoleDepth))
-    fc.ActiveDocument.removeObject(p.Name)
-
-    p = fc.ActiveDocument.addObject("Part::RegularPolygon")
-    p.Polygon = n_sides
-    p.Circumradius = radius
-    p.Placement = fc.Placement(
-        fc.Vector(x_hole_pos, -y_hole_pos),
-        rot,
-    )
-    p.recompute()
-    f = Part.Face(Part.Wire(p.Shape.Edges))
-    c2 = f.extrude(fc.Vector(0, 0, -obj.MagnetHoleDepth))
-    fc.ActiveDocument.removeObject(p.Name)
-
-    p = fc.ActiveDocument.addObject("Part::RegularPolygon")
-    p.Polygon = n_sides
-    p.Circumradius = radius
-    p.Placement = fc.Placement(fc.Vector(-x_hole_pos, y_hole_pos), rot)
-    p.recompute()
-    f = Part.Face(Part.Wire(p.Shape.Edges))
-    c3 = f.extrude(fc.Vector(0, 0, -obj.MagnetHoleDepth))
-    fc.ActiveDocument.removeObject(p.Name)
-
-    p = fc.ActiveDocument.addObject("Part::RegularPolygon")
-    p.Polygon = n_sides
-    p.Circumradius = radius
-    p.Placement = fc.Placement(fc.Vector(x_hole_pos, y_hole_pos), rot)
-    p.recompute()
-    f = Part.Face(Part.Wire(p.Shape.Edges))
-    c4 = f.extrude(fc.Vector(0, 0, -obj.MagnetHoleDepth))
-    fc.ActiveDocument.removeObject(p.Name)
-
-    return c1.multiFuse([c2, c3, c4])
-
-
-def _single_magnet_hole_hex(
-    obj: fc.DocumentObject,
 ) -> Part.Shape:
     # Ratio of 2/sqrt(3) converts from inscribed circle radius to circumscribed circle radius
     radius = obj.MagnetHoleDiameter / math.sqrt(3)
@@ -217,7 +165,7 @@ def make_magnet_holes(obj: fc.DocumentObject, layout: GridfinityLayout) -> Part.
 
     # Magnet holes
     if obj.MagnetHolesShape == "Hex":
-        hm1 = _single_magnet_hole_hex(obj)
+        hm1 = _magnet_hole_hex(obj)
     elif obj.MagnetHolesShape == "Round":
         hm1 = _magnet_hole_round(obj)
     else:

--- a/freecad/gridfinity_workbench/baseplate_feature_construction.py
+++ b/freecad/gridfinity_workbench/baseplate_feature_construction.py
@@ -217,24 +217,23 @@ def make_magnet_holes(obj: fc.DocumentObject, layout: GridfinityLayout) -> Part.
 
     # Magnet holes
     if obj.MagnetHolesShape == "Hex":
-        hm1 = utils.copy_in_corners(_single_magnet_hole_hex(obj), x_hole_pos, y_hole_pos)
+        hm1 = _single_magnet_hole_hex(obj)
     elif obj.MagnetHolesShape == "Round":
-        hm1 = utils.copy_in_corners(_magnet_hole_round(obj), x_hole_pos, y_hole_pos)
+        hm1 = _magnet_hole_round(obj)
     else:
         raise ValueError(f"Unexpected hole shape: {obj.MagnetHolesShape}")
 
     # Screw holes
-    ca = [
-        Part.makeCylinder(
-            obj.MagnetBaseHole / 2,
-            obj.MagnetHoleDepth + obj.BaseThickness,
-            pos,
-            fc.Vector(0, 0, -1),
-        )
-        for pos in utils.corners(x_hole_pos, -y_hole_pos)
-    ]
+    ca = Part.makeCylinder(
+        obj.MagnetBaseHole / 2,
+        obj.MagnetHoleDepth + obj.BaseThickness,
+        fc.Vector(),
+        fc.Vector(0, 0, -1),
+    )
 
-    hm1 = hm1.multiFuse(ca)
+    hm1 = hm1.fuse(ca)
+    hm1 = utils.copy_in_corners(hm1, x_hole_pos, y_hole_pos)
+
     hm1.translate(fc.Vector(obj.xGridSize / 2, obj.yGridSize / 2))
 
     hm2 = utils.copy_in_layout(hm1, layout, obj.xGridSize, obj.yGridSize)

--- a/freecad/gridfinity_workbench/baseplate_feature_construction.py
+++ b/freecad/gridfinity_workbench/baseplate_feature_construction.py
@@ -19,7 +19,6 @@ def _magnet_hole_hex(
 ) -> Part.Shape:
     # Ratio of 2/sqrt(3) converts from inscribed circle radius to circumscribed circle radius
     radius = obj.MagnetHoleDiameter / math.sqrt(3)
-
     n_sides = 6
     rot = fc.Rotation(fc.Vector(0, 0, 1), 0)
 
@@ -63,6 +62,26 @@ def _magnet_hole_hex(
     fc.ActiveDocument.removeObject(p.Name)
 
     return c1.multiFuse([c2, c3, c4])
+
+
+def _single_magnet_hole_hex(
+    obj: fc.DocumentObject,
+) -> Part.Shape:
+    # Ratio of 2/sqrt(3) converts from inscribed circle radius to circumscribed circle radius
+    radius = obj.MagnetHoleDiameter / math.sqrt(3)
+    n_sides = 6
+    rot = fc.Rotation(fc.Vector(0, 0, 1), 0)
+
+    p = fc.ActiveDocument.addObject("Part::RegularPolygon")
+    p.Polygon = n_sides
+    p.Circumradius = radius
+    p.Placement = fc.Placement(fc.Vector(), rot)
+    p.recompute()
+    f = Part.Face(Part.Wire(p.Shape.Edges))
+    hole = f.extrude(fc.Vector(0, 0, -obj.MagnetHoleDepth))
+    fc.ActiveDocument.removeObject(p.Name)
+
+    return hole
 
 
 def _magnet_hole_round(obj: fc.DocumentObject) -> Part.Shape:
@@ -198,7 +217,7 @@ def make_magnet_holes(obj: fc.DocumentObject, layout: GridfinityLayout) -> Part.
 
     # Magnet holes
     if obj.MagnetHolesShape == "Hex":
-        hm1 = _magnet_hole_hex(obj, x_hole_pos, y_hole_pos)
+        hm1 = utils.copy_in_corners(_single_magnet_hole_hex(obj), x_hole_pos, y_hole_pos)
     elif obj.MagnetHolesShape == "Round":
         hm1 = utils.copy_in_corners(_magnet_hole_round(obj), x_hole_pos, y_hole_pos)
     else:

--- a/freecad/gridfinity_workbench/utils.py
+++ b/freecad/gridfinity_workbench/utils.py
@@ -93,6 +93,12 @@ def copy_in_layout(
     return copy_and_translate(shape, vec_list)
 
 
+def copy_in_corners(shape: Part.Shape, x: float, y: float, z: float = 0) -> Part.Shape:
+    """Copy shape to points located at (±x, ±y, z)."""
+    vec_l = corners(x, y, z)
+    return copy_and_translate(shape, vec_l)
+
+
 def copy_in_grid(
     shape: Part.Shape,
     *,

--- a/tests/test_unit_utils.py
+++ b/tests/test_unit_utils.py
@@ -63,6 +63,19 @@ class UtilsTest(unittest.TestCase):
         )
         self.assertEqual(shapes, shape.translated().multiFuse())
 
+    def test_copy_in_corners(self) -> None:
+        shape = mock.MagicMock(spec=Part.Shape)
+        x, y, z = 3, 4, 5
+        utils.copy_in_corners(shape, x, y, z)
+        shape.translated.assert_has_calls(
+            [
+                mock.call(fc.Vector(-x, -y, z)),
+                mock.call(fc.Vector(x, -y, z)),
+                mock.call(fc.Vector(-x, y, z)),
+                mock.call(fc.Vector(x, y, z)),
+            ],
+        )
+
     def test_curve_to_wire_empty_list(self) -> None:
         self.assertRaises(ValueError, utils.curve_to_wire, [])
 


### PR DESCRIPTION
Refactor some hole creation which makes code more readable and is more than 4x faster.

My goal is to add some more small improvements so:
* low level functions don't need high level knowledge (a function that creates a shape of a hole should not have the knowledge to copy it in an array on specific locations. This improvement should improve re-usability)
* Remove the use of `freecad.DocumentObject` as much as possible as this makes it hard to test. (creating a cylinder with `height` and `radius` is more readable and logic than a creating it with a `DocumentObject` argument.