### PR TITLE
Add scoop functionality to EcoBin classes

### DIFF
--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -4,9 +4,8 @@
 
 from abc import abstractmethod
 
-import Part
-
 import FreeCAD as fc  # noqa: N813
+import Part
 
 from . import baseplate_feature_construction as baseplate_feat
 from . import check_version, const, grid_initial_layout, label_shelf, utils
@@ -318,11 +317,7 @@ class EcoBin(FoundationGridfinity):
 
         # Now add scoop, but only where eco compartments exist (reversed logic)
         if obj.Scoop:
-            # Store original UsableHeight and adjust for eco bin's deeper compartment
-            original_usable_height = obj.UsableHeight
-            obj.UsableHeight = obj.TotalHeight - obj.BaseWallThickness
-            scoop = feat.make_scoop(obj)
-            obj.UsableHeight = original_usable_height  # Restore original value
+            scoop = feat.make_scoop(obj, usable_height=obj.TotalHeight - obj.BaseWallThickness)
             # Only add scoop where compartments exist - use intersection to constrain
             scoop_constrained = scoop.common(eco_compartments)
             fuse_total = fuse_total.fuse(scoop_constrained)
@@ -682,11 +677,7 @@ class CustomEcoBin(FoundationGridfinity):
 
         # Now add scoop, but only where eco compartments exist (reversed logic)
         if obj.Scoop:
-            # Store original UsableHeight and adjust for eco bin's deeper compartment
-            original_usable_height = obj.UsableHeight
-            obj.UsableHeight = obj.TotalHeight - obj.BaseWallThickness
-            scoop = feat.make_scoop(obj)
-            obj.UsableHeight = original_usable_height  # Restore original value
+            scoop = feat.make_scoop(obj, usable_height=obj.TotalHeight - obj.BaseWallThickness)
             # Only add scoop where compartments exist - use intersection to constrain
             scoop_constrained = scoop.common(compartments)
             fuse_total = fuse_total.fuse(scoop_constrained)

--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -4,8 +4,9 @@
 
 from abc import abstractmethod
 
-import FreeCAD as fc  # noqa: N813
 import Part
+
+import FreeCAD as fc  # noqa: N813
 
 from . import baseplate_feature_construction as baseplate_feat
 from . import check_version, const, grid_initial_layout, label_shelf, utils
@@ -270,6 +271,7 @@ class EcoBin(FoundationGridfinity):
         feat.bin_base_values_properties(obj)
         feat.label_shelf_properties(obj, label_style_default="Standard")
         feat.eco_compartments_properties(obj)
+        feat.scoop_properties(obj, scoop_default=False)
 
         obj.setExpression("UsableHeight", "TotalHeight - HeightUnitValue")
 
@@ -309,7 +311,21 @@ class EcoBin(FoundationGridfinity):
         compartment_solid = face.extrude(
             fc.Vector(0, 0, obj.TotalHeight - obj.BaseProfileHeight - obj.BaseWallThickness),
         )
-        fuse_total = fuse_total.cut(feat.make_eco_compartments(obj, layout, compartment_solid))
+
+        # First cut eco compartments to create the interior spaces
+        eco_compartments = feat.make_eco_compartments(obj, layout, compartment_solid)
+        fuse_total = fuse_total.cut(eco_compartments)
+
+        # Now add scoop, but only where eco compartments exist (reversed logic)
+        if obj.Scoop:
+            # Store original UsableHeight and adjust for eco bin's deeper compartment
+            original_usable_height = obj.UsableHeight
+            obj.UsableHeight = obj.TotalHeight - obj.BaseWallThickness
+            scoop = feat.make_scoop(obj)
+            obj.UsableHeight = original_usable_height  # Restore original value
+            # Only add scoop where compartments exist - use intersection to constrain
+            scoop_constrained = scoop.common(eco_compartments)
+            fuse_total = fuse_total.fuse(scoop_constrained)
 
         if obj.ScrewHoles or obj.MagnetHoles:
             fuse_total = fuse_total.cut(feat.make_bin_bottom_holes(obj, layout))
@@ -602,6 +618,7 @@ class CustomEcoBin(FoundationGridfinity):
         feat.bin_base_values_properties(obj)
         feat.label_shelf_properties(obj, label_style_default="Off")
         feat.eco_compartments_properties(obj)
+        feat.scoop_properties(obj, scoop_default=False)
 
         obj.Proxy = self
 
@@ -657,10 +674,22 @@ class CustomEcoBin(FoundationGridfinity):
             inside_wall_solid_full_height,
             obj.BinOuterRadius - obj.WallThickness,
         )
+        # First cut eco compartments to create the interior spaces
         compartments = feat.make_eco_compartments(obj, layout, compartments_solid)
         inside_wall_negative = cut_outside_shape(obj, inside_wall_solid_full_height)
         compartments = compartments.cut(inside_wall_negative)
         fuse_total = fuse_total.cut(compartments)
+
+        # Now add scoop, but only where eco compartments exist (reversed logic)
+        if obj.Scoop:
+            # Store original UsableHeight and adjust for eco bin's deeper compartment
+            original_usable_height = obj.UsableHeight
+            obj.UsableHeight = obj.TotalHeight - obj.BaseWallThickness
+            scoop = feat.make_scoop(obj)
+            obj.UsableHeight = original_usable_height  # Restore original value
+            # Only add scoop where compartments exist - use intersection to constrain
+            scoop_constrained = scoop.common(compartments)
+            fuse_total = fuse_total.fuse(scoop_constrained)
 
         if obj.LabelShelfStyle != "Off":
             label_shelf = feat.make_label_shelf(obj, "eco")

--- a/freecad/gridfinity_workbench/utils.py
+++ b/freecad/gridfinity_workbench/utils.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING
 
-import FreeCAD as fc  # noqa:N813
+import FreeCAD as fc  # noqa: N813
 import FreeCADGui as fcg  # noqa: N813
 import Part
 

--- a/freecad/gridfinity_workbench/version.py
+++ b/freecad/gridfinity_workbench/version.py
@@ -1,3 +1,3 @@
 """Module containing version information."""
 
-__version__ = "0.12.2"
+__version__ = "0.12.3"

--- a/package.xml
+++ b/package.xml
@@ -5,9 +5,9 @@
 
   <description>This Workbench will generate several variations of parametric Gridfinity bins and baseplates that can be easily customized. </description>
 
-  <version>0.12.2</version>
+  <version>0.12.3</version>
 
-  <date>2026-02-28</date>
+  <date>2026-03-03</date>
 
   <license file="LICENSE">lgpl-2.1-or-later</license>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,6 @@ ignore = ["ANN003", "EM101", "EM102", "RET504", "TRY003", "S101", "SIM300"]
 # PT009  - pytest-unittest-assertion: we use unittest framework, not pytest
 "**/tests/*" = ["INP001", "D100", "D101", "D102", "PT027", "PT009"]
 "freecad/gridfinity_workbench/test_gridfinity.py" = ["D100", "D101", "D102", "PT027", "PT009"]
+
+[tool.ruff.lint.isort]
+known-third-party = ["FreeCAD", "FreeCADGui", "Part"]


### PR DESCRIPTION
Hi, many thanks for this Addon, I love it. I was just missing the scoop for EcoBins.

This PR extends scoop support to both `EcoBin` and `CustomEcoBin` classes, bringing feature parity with standard storage bins.

## Changes

- EcoBin: Added scoop properties and shape generation logic
- CustomEcoBin: Added scoop properties with proper custom shape integration (scoop is trimmed by `inside_wall_negative`

Both classes now expose `Scoop` (boolean) and `ScoopRadius` (length) properties in the UI. Default scoop value set to False for backward compatibility

## Implementation

The implementation reuses the existing `make_scoop()` function and follows established patterns used by other features like label shelves. For `CustomEcoBin`, the scoop is properly cut by the inside wall negative to handle custom shapes correctly.

## Testing

- Code passes linting (ruff) and type checking (mypy)
- I could not identify any breaking changes to existing functionality
- Maintains backward compatibility with existing EcoBin objects

This addresses the feature gap where scoops were available in standard bins but missing from eco bins.

Here's an EcoBin with a scoop (radius: 12mm)

<img width="951" height="672" alt="image" src="https://github.com/user-attachments/assets/7d823c0a-180e-4552-bbe1-6eecc0f8ff0b" />

The underside is unaffected:
<img width="763" height="643" alt="image" src="https://github.com/user-attachments/assets/eb0f4223-f392-4a05-8a23-a079cf0ba056" />

It also works for 1x1 EcoBins
<img width="466" height="443" alt="image" src="https://github.com/user-attachments/assets/f30ae6fc-afe8-485b-9585-a472879ecc9b" />

and custom EcoBins
<img width="678" height="749" alt="image" src="https://github.com/user-attachments/assets/049c1752-6dd0-4765-8d57-64d7a07bdb8a" />
