### PR TITLE
Updates for the object version migration.

### DIFF
--- a/freecad/gridfinity_workbench/check_version.py
+++ b/freecad/gridfinity_workbench/check_version.py
@@ -27,6 +27,19 @@ def migrate_object_version(obj: fc.DocumentObject) -> None:  # noqa: C901
 
     ### v0.11.9 Changes ###
 
+    if (
+        getattr(obj, "Baseplate", False)
+        and hasattr(obj, "MagnetHoles")
+        and not hasattr(obj, "MagnetHoleChamfer")
+    ):
+        # Add property for the magnet hole chamfer.
+        obj.addProperty(
+            "App::PropertyLength",
+            "MagnetHoleChamfer",
+            "GridfinityNonStandard",
+            "The depth at which magnet hole chamfer starts.",
+        ).MagnetHoleChamfer = 0.25
+
     if hasattr(obj, "MagnetHoles"):
         # Add properties for the crush ribs to hold magnets.
         if not hasattr(obj, "CrushRibsCount"):


### PR DESCRIPTION
This PR makes changes to `check_version.migrate_object_version()` to:

1. Rewrite to make decisions on migrating properties by inspecting the properties, rather than inspecting the object version number.
   - This makes it easier for PRs to add migrations without knowing what the version number will be when the PR is merged.
1. Add migration for the `StackingLipThinStyle` property added in v0.12.1.
1. Add migration for the `MagnetHoleChamfer` property for Magnet Baseplates added in v0.11.9.

I suggest that future PRs which add or modify object properties should be required to **either**:
- ensure they work correctly when new expected properties are absent or in the wrong format OR
- add code to `check_version.py` to update properties to ensure backward compatibility.

@Stu142 and @greg19: This PR is necessary to ensure the thin stacking lip style can be added to objects loaded from versions of the workbench prior to v0.12.1.

I have tested backward compatibility as far back as v0.11.8. Those tests have simply to ensure each of the objects can be recomputed without any errors or warnings and some minor changes to the object properties.