### PR TITLE
Fix to correct internal fillet radius on concave edges of custom bins.

### DIFF
--- a/freecad/gridfinity_workbench/features.py
+++ b/freecad/gridfinity_workbench/features.py
@@ -17,6 +17,7 @@ from .custom_shape_features import (
     custom_shape_trim,
     cut_outside_shape,
     vertical_edge_fillet,
+    vertical_edge_fillet_with_concave_edges,
 )
 from .version import __version__
 
@@ -748,9 +749,10 @@ class CustomStorageBin(FoundationGridfinity):
         )
         compartments_solid = compartments_solid.cut(compartment_trim)
         compartments_solid = compartments_solid.removeSplitter()
-        compartments_solid = vertical_edge_fillet(
+        compartments_solid = vertical_edge_fillet_with_concave_edges(
             compartments_solid,
             obj.BinOuterRadius - obj.WallThickness,
+            obj.BinOuterRadius + obj.WallThickness,
         )
         compartments = feat.make_compartments(obj, compartments_solid)
 

--- a/freecad/gridfinity_workbench/version.py
+++ b/freecad/gridfinity_workbench/version.py
@@ -1,3 +1,3 @@
 """Module containing version information."""
 
-__version__ = "0.12.2"
+__version__ = "0.12.4"

--- a/package.xml
+++ b/package.xml
@@ -5,9 +5,9 @@
 
   <description>This Workbench will generate several variations of parametric Gridfinity bins and baseplates that can be easily customized. </description>
 
-  <version>0.12.2</version>
+  <version>0.12.4</version>
 
-  <date>2026-02-28</date>
+  <date>2026-03-03</date>
 
   <license file="LICENSE">lgpl-2.1-or-later</license>
 


### PR DESCRIPTION
This PR uses a different fillet radius for the internal compartments at "concave" edges of custom bins shapes. These edges require a larger fillet radius than the usual "convex" edges of ordinary bins (See the first diagram).

Adds `vertical_edge_fillet_with_concave_edges()` function to `custom_shape_features.py` that applies different fillet radii to concave and convex vertical edges of a solid.

This is used by `CustomStorageBin` to apply a larger fillet radius to vertical edges of the compartments which correspond to externally concave edges.

The first image shows the effect of the incorrect radius on concave edges (WallThickness=2.0mm). The second image shows the "correct" radius used on those edges.

<img width="400" height="888" alt="Screenshot from 2026-03-02 00-06-36" src="https://github.com/user-attachments/assets/5206abaf-17d5-4729-a131-8946071a01b3" />
<img width="400" height="894" alt="Screenshot from 2026-03-02 00-07-10" src="https://github.com/user-attachments/assets/e5beebfe-7c9e-4a40-955a-143e1cce2bee" />
