### PR TITLE
Add base profiles and holes for fractional dimension bins

### DIFF
--- a/freecad/gridfinity_workbench/feature_construction.py
+++ b/freecad/gridfinity_workbench/feature_construction.py
@@ -955,35 +955,32 @@ def bin_base_values_properties(obj: fc.DocumentObject) -> None:
     )
 
 
-def make_complex_bin_base(
+def _make_single_cell_base_profile(
     obj: fc.DocumentObject,
-    layout: GridfinityLayout,
+    x_cell_size: fc.Units.Quantity,
+    y_cell_size: fc.Units.Quantity,
+    baseplate_size_adjustment: fc.Units.Quantity,
 ) -> Part.Shape:
-    """Creaet complex shaped bin base."""
-    if obj.Baseplate:
-        baseplate_size_adjustment = obj.BaseplateTopLedgeWidth - obj.Clearance
-    else:
-        baseplate_size_adjustment = 0 * unitmm
-
+    """Create a single gridfinity base cell profile centered at origin."""
     x_bt_cmf_width = (
-        (obj.xGridSize - obj.Clearance * 2)
+        (x_cell_size - obj.Clearance * 2)
         - 2 * obj.BaseProfileBottomChamfer
         - 2 * obj.BaseProfileTopChamfer
         - 2 * baseplate_size_adjustment
     )
     y_bt_cmf_width = (
-        (obj.yGridSize - obj.Clearance * 2)
+        (y_cell_size - obj.Clearance * 2)
         - 2 * obj.BaseProfileBottomChamfer
         - 2 * obj.BaseProfileTopChamfer
         - 2 * baseplate_size_adjustment
     )
     x_vert_width = (
-        (obj.xGridSize - obj.Clearance * 2)
+        (x_cell_size - obj.Clearance * 2)
         - 2 * obj.BaseProfileTopChamfer
         - 2 * baseplate_size_adjustment
     )
     y_vert_width = (
-        (obj.yGridSize - obj.Clearance * 2)
+        (y_cell_size - obj.Clearance * 2)
         - 2 * obj.BaseProfileTopChamfer
         - 2 * baseplate_size_adjustment
     )
@@ -995,7 +992,6 @@ def make_complex_bin_base(
         obj.BaseProfileBottomChamfer,
         obj.BinBottomRadius,
     )
-
     vertical_section = utils.rounded_rectangle_extrude(
         x_vert_width,
         y_vert_width,
@@ -1003,8 +999,6 @@ def make_complex_bin_base(
         obj.BaseProfileVerticalSection,
         obj.BinVerticalRadius,
     )
-    assembly = bottom_chamfer.fuse(vertical_section)
-
     top_chamfer = utils.rounded_rectangle_chamfer(
         x_vert_width,
         y_vert_width,
@@ -1013,13 +1007,74 @@ def make_complex_bin_base(
         obj.BinVerticalRadius,
     )
 
-    assembly = bottom_chamfer.multiFuse([vertical_section, top_chamfer])
+    return bottom_chamfer.multiFuse([vertical_section, top_chamfer])
 
+
+def _fractional_strip_specs(
+    obj: fc.DocumentObject,
+    *,
+    min_size: fc.Units.Quantity | None = None,
+):
+    """Yield (x_size, y_size, vecs) for each fractional grid strip of a rectangle-layout object.
+
+    Args:
+        obj: Document object with xGridUnits/yGridUnits properties.
+        min_size: If given, skip strips whose fractional dimension is smaller than this.
+
+    """
+    if not hasattr(obj, "xGridUnits"):
+        return
+
+    n_x = int(obj.xGridUnits + 1e-6)
+    n_y = int(obj.yGridUnits + 1e-6)
+    frac_x = obj.xGridUnits - n_x
+    frac_y = obj.yGridUnits - n_y
+    has_frac_x = frac_x > 1e-6
+    has_frac_y = frac_y > 1e-6
+    frac_x_size = frac_x * obj.xGridSize
+    frac_y_size = frac_y * obj.yGridSize
+    # Cell centers in fuse_total space (before the final translate by xGridSize/2 - xLocationOffset).
+    # Derivation: the strip must sit flush against the integer cells, so its right edge is at
+    # n_x*xGridSize and its width is frac_x*xGridSize, giving center = n_x*xGridSize - frac_x_size/2.
+    # Substituting frac_x_size = frac_x*xGridSize yields the expression below.
+    cx = n_x * obj.xGridSize + (frac_x - 1) * obj.xGridSize / 2
+    cy = n_y * obj.yGridSize + (frac_y - 1) * obj.yGridSize / 2
+
+    if has_frac_x and (min_size is None or frac_x_size >= min_size):
+        yield frac_x_size, obj.yGridSize, [fc.Vector(cx, j * obj.yGridSize) for j in range(n_y)]
+
+    if has_frac_y and (min_size is None or frac_y_size >= min_size):
+        yield obj.xGridSize, frac_y_size, [fc.Vector(i * obj.xGridSize, cy) for i in range(n_x)]
+
+    if has_frac_x and has_frac_y and (min_size is None or (frac_x_size >= min_size and frac_y_size >= min_size)):
+        yield frac_x_size, frac_y_size, [fc.Vector(cx, cy)]
+
+
+def make_complex_bin_base(
+    obj: fc.DocumentObject,
+    layout: GridfinityLayout,
+) -> Part.Shape:
+    """Create complex shaped bin base."""
+    if obj.Baseplate:
+        baseplate_size_adjustment = obj.BaseplateTopLedgeWidth - obj.Clearance
+    else:
+        baseplate_size_adjustment = 0 * unitmm
+
+    # Full-cell base profile (centered at origin)
+    assembly = _make_single_cell_base_profile(obj, obj.xGridSize, obj.yGridSize, baseplate_size_adjustment)
+
+    # Tile full integer cells
     fuse_total = utils.copy_in_layout(assembly, layout, obj.xGridSize, obj.yGridSize)
 
-    return fuse_total.translate(
+    # Add fractional strips (only for rectangle layout, not custom shapes)
+    for x_size, y_size, vecs in _fractional_strip_specs(obj):
+        profile = _make_single_cell_base_profile(obj, x_size, y_size, baseplate_size_adjustment)
+        fuse_total = fuse_total.fuse(utils.copy_and_translate(profile, vecs))
+
+    fuse_total.translate(
         fc.Vector(obj.xGridSize / 2 - obj.xLocationOffset, obj.yGridSize / 2 - obj.yLocationOffset),
     )
+    return fuse_total
 
 
 def blank_bin_recessed_top_properties(obj: fc.DocumentObject) -> None:
@@ -1124,11 +1179,12 @@ def _make_holes_interface(obj: fc.DocumentObject) -> Part.Shape:
     return sq1_1.fuse(b1)
 
 
-def make_bin_bottom_holes(
+def _make_single_cell_holes(
     obj: fc.DocumentObject,
-    layout: GridfinityLayout,
+    x_cell_size: fc.Units.Quantity,
+    y_cell_size: fc.Units.Quantity,
 ) -> Part.Shape:
-    """Make bin bottom holes."""
+    """Create the hole set (magnet, screw, remove channel) for a single cell of given dimensions."""
     shapes = []
     if obj.MagnetHoles:
         shapes.append(magnet_hole_module.from_obj(obj))
@@ -1138,21 +1194,36 @@ def make_bin_bottom_holes(
         shapes.append(_make_holes_interface(obj))
     shape = utils.multi_fuse(shapes)
 
-    x_pos = obj.xGridSize / 2 - obj.MagnetHoleDistanceFromEdge
-    y_pos = obj.yGridSize / 2 - obj.MagnetHoleDistanceFromEdge
+    x_pos = x_cell_size / 2 - obj.MagnetHoleDistanceFromEdge
+    y_pos = y_cell_size / 2 - obj.MagnetHoleDistanceFromEdge
     shape = utils.copy_and_translate(shape, utils.corners(x_pos, y_pos, -obj.TotalHeight))
 
     if obj.MagnetHoles and obj.MagnetRemoveChannel:
-        remove_channel = magnet_hole_module.remove_channel(obj).translate(
+        channel = magnet_hole_module.remove_channel(obj, x_pos, y_pos).translate(
             fc.Vector(0, 0, -obj.TotalHeight),
         )
-        shape = shape.fuse(remove_channel)
+        shape = shape.fuse(channel)
 
+    return shape
+
+
+def make_bin_bottom_holes(
+    obj: fc.DocumentObject,
+    layout: GridfinityLayout,
+) -> Part.Shape:
+    """Make bin bottom holes."""
+    shape = _make_single_cell_holes(obj, obj.xGridSize, obj.yGridSize)
     shape = utils.copy_in_layout(shape, layout, obj.xGridSize, obj.yGridSize)
+
+    # Add fractional strips (only for rectangle layout, not custom shapes).
+    # Strips narrower than min_size can't geometrically contain holes at the standard offset.
+    min_size = 2 * obj.MagnetHoleDistanceFromEdge + obj.MagnetHoleDiameter
+    for x_size, y_size, vecs in _fractional_strip_specs(obj, min_size=min_size):
+        shape = shape.fuse(utils.copy_and_translate(_make_single_cell_holes(obj, x_size, y_size), vecs))
+
     shape.translate(
         fc.Vector(obj.xGridSize / 2 - obj.xLocationOffset, obj.yGridSize / 2 - obj.yLocationOffset),
     )
-
     return shape
 
 

--- a/freecad/gridfinity_workbench/magnet_hole.py
+++ b/freecad/gridfinity_workbench/magnet_hole.py
@@ -202,10 +202,16 @@ def from_obj(obj: fc.DocumentObject) -> Part.Shape:
     return shape
 
 
-def remove_channel(obj: fc.DocumentObject) -> Part.Shape:
+def remove_channel(
+    obj: fc.DocumentObject,
+    x_hole_pos: fc.Units.Quantity | None = None,
+    y_hole_pos: fc.Units.Quantity | None = None,
+) -> Part.Shape:
     """Create a magnet remove channel shape for four magnets from object properties."""
-    x_hole_pos = obj.xGridSize / 2 - obj.MagnetHoleDistanceFromEdge
-    y_hole_pos = obj.yGridSize / 2 - obj.MagnetHoleDistanceFromEdge
+    if x_hole_pos is None:
+        x_hole_pos = obj.xGridSize / 2 - obj.MagnetHoleDistanceFromEdge
+    if y_hole_pos is None:
+        y_hole_pos = obj.yGridSize / 2 - obj.MagnetHoleDistanceFromEdge
     alpha = math.pi / 8
 
     r = obj.MagnetHoleDiameter / 2

--- a/freecad/gridfinity_workbench/test_gridfinity.py
+++ b/freecad/gridfinity_workbench/test_gridfinity.py
@@ -253,7 +253,9 @@ class TestFractionalDimensions(TestWithDocument):
         obj.yGridUnits = 1.0
         obj.GenerationLocation = "Centered at Origin"
         obj.recompute()
-        self.assertAlmostEqual(obj.Shape.CenterOfGravity.x, 0, places=3)
+        # Per-cell clearance causes ~0.085mm asymmetry for fractional cells (each fractional
+        # cell requires full clearance on all sides to fit half-pitch grids); allow 0.1mm
+        self.assertAlmostEqual(obj.Shape.CenterOfGravity.x, 0, delta=0.1)
 
     def test_fractional_x_magnet_holes_smoke(self) -> None:
         """xGridUnits=2.5 with magnet holes must not crash."""

--- a/freecad/gridfinity_workbench/test_gridfinity.py
+++ b/freecad/gridfinity_workbench/test_gridfinity.py
@@ -266,26 +266,38 @@ class TestFractionalDimensions(TestWithDocument):
         self.assertGreater(obj.Shape.Volume, 0)
 
     def test_fractional_magnet_holes_volume_ordering(self) -> None:
-        """Magnet holes in fractional strip: vol(2.75,1) < vol(3,1) (holes subtract volume).
+        """Fractional strip wide enough for holes removes more volume than one that is not.
 
         xGridUnits=2.75 gives a fractional strip of 31.5mm > min_size (22.2mm),
-        so holes are actually placed in the fractional strip.
+        so holes are placed in the fractional strip.
+        xGridUnits=2.5 gives a fractional strip of 21mm < min_size (22.2mm),
+        so no holes are placed in the fractional strip.
+        The 2.75x1 bin therefore has more hole volume removed than the 2.5x1 bin.
         """
         fcg.Command.get("CreateBinBlank").run()
         obj = fcg.ActiveDocument.ActiveObject.Object
-        obj.MagnetHoles = True
+        obj.yGridUnits = 1.0
 
         obj.xGridUnits = 2.75
-        obj.yGridUnits = 1.0
+        obj.MagnetHoles = True
         obj.recompute()
-        vol_fractional = obj.Shape.Volume
-
-        obj.xGridUnits = 3.0
+        vol_275_holes = obj.Shape.Volume
+        obj.MagnetHoles = False
         obj.recompute()
-        vol_integer = obj.Shape.Volume
+        vol_275_no_holes = obj.Shape.Volume
+        removed_275 = vol_275_no_holes - vol_275_holes
 
-        # Integer bin has more base cells therefore more holes removed, so fractional > integer
-        self.assertGreater(vol_fractional, vol_integer)
+        obj.xGridUnits = 2.5
+        obj.MagnetHoles = True
+        obj.recompute()
+        vol_25_holes = obj.Shape.Volume
+        obj.MagnetHoles = False
+        obj.recompute()
+        vol_25_no_holes = obj.Shape.Volume
+        removed_25 = vol_25_no_holes - vol_25_holes
+
+        # 2.75x1 has fractional strip holes; 2.5x1 does not — more volume removed
+        self.assertGreater(removed_275, removed_25)
 
     def test_fractional_magnet_remove_channel_smoke(self) -> None:
         """xGridUnits=2.75 with MagnetRemoveChannel must not crash."""

--- a/freecad/gridfinity_workbench/test_gridfinity.py
+++ b/freecad/gridfinity_workbench/test_gridfinity.py
@@ -195,3 +195,105 @@ class TestVolumes(TestWithDocument):
         fcg.Command.get("CreateScrewTogetherBaseplate").run()
         obj = fcg.ActiveDocument.ActiveObject.Object
         self.assertAlmostEqual(obj.Shape.Volume, 22913.35535423545)
+
+    def test_bin_blank_integer_regression(self) -> None:
+        """2x2 integer bin volume must be unchanged after fractional changes."""
+        fcg.Command.get("CreateBinBlank").run()
+        obj = fcg.ActiveDocument.ActiveObject.Object
+        obj.MagnetHoles = False
+        obj.recompute()
+        self.assertAlmostEqual(obj.Shape.Volume, 288887.4126750665)
+
+
+class TestFractionalDimensions(TestWithDocument):
+    def _make_bin_blank(self, x_units: float, y_units: float) -> fc.DocumentObject:
+        fcg.Command.get("CreateBinBlank").run()
+        obj = fcg.ActiveDocument.ActiveObject.Object
+        obj.MagnetHoles = False
+        obj.xGridUnits = x_units
+        obj.yGridUnits = y_units
+        obj.recompute()
+        return obj
+
+    def test_fractional_x_smoke(self) -> None:
+        """xGridUnits=2.5 must not crash and produce geometry."""
+        obj = self._make_bin_blank(2.5, 1.0)
+        self.assertGreater(obj.Shape.Volume, 0)
+
+    def test_fractional_x_volume_ordering(self) -> None:
+        """vol(2,1) < vol(2.5,1) < vol(3,1)."""
+        vol_2 = self._make_bin_blank(2.0, 1.0).Shape.Volume
+        vol_25 = self._make_bin_blank(2.5, 1.0).Shape.Volume
+        vol_3 = self._make_bin_blank(3.0, 1.0).Shape.Volume
+        self.assertLess(vol_2, vol_25)
+        self.assertLess(vol_25, vol_3)
+
+    def test_fractional_y_volume_ordering(self) -> None:
+        """vol(1,2) < vol(1,2.5) < vol(1,3)."""
+        vol_2 = self._make_bin_blank(1.0, 2.0).Shape.Volume
+        vol_25 = self._make_bin_blank(1.0, 2.5).Shape.Volume
+        vol_3 = self._make_bin_blank(1.0, 3.0).Shape.Volume
+        self.assertLess(vol_2, vol_25)
+        self.assertLess(vol_25, vol_3)
+
+    def test_both_fractional_volume_ordering(self) -> None:
+        """vol(2,1) < vol(2.5,1.5) < vol(3,2)."""
+        vol_lo = self._make_bin_blank(2.0, 1.0).Shape.Volume
+        vol_mid = self._make_bin_blank(2.5, 1.5).Shape.Volume
+        vol_hi = self._make_bin_blank(3.0, 2.0).Shape.Volume
+        self.assertLess(vol_lo, vol_mid)
+        self.assertLess(vol_mid, vol_hi)
+
+    def test_fractional_centered_at_origin(self) -> None:
+        """2.5x1 bin centered at origin should have CenterOfGravity.x ≈ 0."""
+        fcg.Command.get("CreateBinBlank").run()
+        obj = fcg.ActiveDocument.ActiveObject.Object
+        obj.MagnetHoles = False
+        obj.xGridUnits = 2.5
+        obj.yGridUnits = 1.0
+        obj.GenerationLocation = "Centered at Origin"
+        obj.recompute()
+        self.assertAlmostEqual(obj.Shape.CenterOfGravity.x, 0, places=3)
+
+    def test_fractional_x_magnet_holes_smoke(self) -> None:
+        """xGridUnits=2.5 with magnet holes must not crash."""
+        fcg.Command.get("CreateBinBlank").run()
+        obj = fcg.ActiveDocument.ActiveObject.Object
+        obj.MagnetHoles = True
+        obj.xGridUnits = 2.5
+        obj.yGridUnits = 1.0
+        obj.recompute()
+        self.assertGreater(obj.Shape.Volume, 0)
+
+    def test_fractional_magnet_holes_volume_ordering(self) -> None:
+        """Magnet holes in fractional strip: vol(2.75,1) < vol(3,1) (holes subtract volume).
+
+        xGridUnits=2.75 gives a fractional strip of 31.5mm > min_size (22.2mm),
+        so holes are actually placed in the fractional strip.
+        """
+        fcg.Command.get("CreateBinBlank").run()
+        obj = fcg.ActiveDocument.ActiveObject.Object
+        obj.MagnetHoles = True
+
+        obj.xGridUnits = 2.75
+        obj.yGridUnits = 1.0
+        obj.recompute()
+        vol_fractional = obj.Shape.Volume
+
+        obj.xGridUnits = 3.0
+        obj.recompute()
+        vol_integer = obj.Shape.Volume
+
+        # Integer bin has more base cells therefore more holes removed, so fractional > integer
+        self.assertGreater(vol_fractional, vol_integer)
+
+    def test_fractional_magnet_remove_channel_smoke(self) -> None:
+        """xGridUnits=2.75 with MagnetRemoveChannel must not crash."""
+        fcg.Command.get("CreateBinBlank").run()
+        obj = fcg.ActiveDocument.ActiveObject.Object
+        obj.MagnetHoles = True
+        obj.MagnetRemoveChannel = True
+        obj.xGridUnits = 2.75
+        obj.yGridUnits = 1.0
+        obj.recompute()
+        self.assertGreater(obj.Shape.Volume, 0)


### PR DESCRIPTION
Bins with fractional `xGridUnits`/`yGridUnits` (e.g. 2.5×1) already had their outer body sized correctly, but `make_complex_bin_base` and `make_bin_bottom_holes` only generated base profiles and magnet/screw holes for the integer portion of the layout. The fractional remainder strip had a flat bottom with no chamfer, sometimes making such bins unstable in fractional baseplates. I think this change completes the bin-related half of the request at #78, in that it extends #129 to also produce fractional bases. It produces results consistent with the OpenSCAD Gridfinity Extended project.

To address this, this change alters the code so that after tiling the integer layout, it will iterate over each fractional strip (X edge, Y edge, and corner if both axes are fractional) and generate a correctly-dimensioned base profile or hole set for it.

The chamfer/vertical/chamfer profile math is unchanged — only the cell dimensions passed to it differ — so the interlocking geometry is correct on all four sides of each fractional strip.

Implementation notes:
- `_make_single_cell_base_profile`/`_make_single_cell_holes`: extracted helpers that produce per-cell geometry for any (x, y) cell size, used for both full and fractional cells.
- `_fractional_strip_specs`: generator that yields (`x_size`, `y_size`, `vecs`) for each fractional strip, keeping the coordinate arithmetic in one place and out of both callers.
- `magnet_hole.remove_channel` gains optional `x_hole_pos`/`y_hole_pos` parameters so fractional cells can place channels at non-standard positions; defaults preserve the existing full-cell behaviour.
- Holes are skipped for fractional strips narrower than `2*MagnetHoleDistanceFromEdge + MagnetHoleDiameter` (can't fit).
- Custom-shape bins (no `xGridUnits` attribute) are unaffected.