### PR TITLE
Feature: Additional "Generation Location" options.

### DIFF
--- a/freecad/gridfinity_workbench/grid_initial_layout.py
+++ b/freecad/gridfinity_workbench/grid_initial_layout.py
@@ -12,7 +12,7 @@ def _location_properties(obj: fc.DocumentObject) -> None:
         "GenerationLocation",
         "Gridfinity",
         "Location of the bin. Change depending on how you want to customize",
-    ).GenerationLocation = ["Positive from Origin", "Centered at Origin"]
+    ).GenerationLocation = ["Positive from Origin", "Centered at Origin", "Centered along X Axis", "Centered along Y Axis"]
 
     obj.addProperty(
         "App::PropertyLength",
@@ -121,6 +121,20 @@ def make_rectangle_layout(obj: fc.DocumentObject) -> list[list[bool]]:
             obj.yLocationOffset = obj.yTotalWidth / 2
         else:
             obj.xLocationOffset = obj.xTotalWidth / 2 + obj.Clearance
+            obj.yLocationOffset = obj.yTotalWidth / 2 + obj.Clearance
+    elif obj.GenerationLocation == "Centered along X Axis":
+        if obj.Baseplate:
+            obj.xLocationOffset = obj.xTotalWidth / 2
+            obj.yLocationOffset = 0
+        else:
+            obj.xLocationOffset = obj.xTotalWidth / 2 + obj.Clearance
+            obj.yLocationOffset = obj.Clearance
+    elif obj.GenerationLocation == "Centered along Y Axis":
+        if obj.Baseplate:
+            obj.xLocationOffset = 0
+            obj.yLocationOffset = obj.yTotalWidth / 2
+        else:
+            obj.xLocationOffset = obj.Clearance
             obj.yLocationOffset = obj.yTotalWidth / 2 + obj.Clearance
     else:
         obj.xLocationOffset = 0


### PR DESCRIPTION
While designing Gridfinity bins that were symmetric along the y-axis, I found it helpful to locate the bin centered along the corresponding axis. That's what this PR implements.

Centered along x-axis:
<img width="1267" height="680" alt="image" src="https://github.com/user-attachments/assets/169719ad-ca4e-43b8-bf8b-a859051d3c5f" />

Centered along y-axis
<img width="1267" height="663" alt="image" src="https://github.com/user-attachments/assets/9fdb5d26-151c-4dd3-b3ad-9c7dbc21d49e" />

Works also with the other bin types as well as the baseplates.